### PR TITLE
Prevent the add-item field from auto-focusing on launch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.JhowShoppList">
+            android:theme="@style/Theme.JhowShoppList"
+            android:windowSoftInputMode="stateHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -40,10 +40,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -90,6 +92,12 @@ fun ShoppingListScreen(
     onDeleteItemConfirmed: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(Unit) {
+        focusManager.clearFocus(force = true)
+    }
+
     Scaffold(
         modifier = modifier
             .fillMaxSize()


### PR DESCRIPTION
## Summary
- keep the add-item field from requesting focus automatically when the screen first opens
- start the activity with the soft keyboard hidden so the list stays visible until the user taps the input
- validate the fix by compiling, installing on the Pixel 6, relaunching the app, and checking the input method state through adb