### PR TITLE
Refactor: remove tutorial hints from UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — JhowShoppList
 
-Android Kotlin shopping-list app built with Jetpack Compose, Room, Hilt, and Clean Architecture.
+Android Kotlin shopping-list app built with Jetpack Compose, Room, Hilt, and Clean Architecture. Proposing sweeping changes that improve long-term maintainability is encouraged.
 
 ## Build / Lint / Test Commands
 
@@ -31,6 +31,18 @@ app/src/
   androidTest/java/- Compose UI + Room DAO instrumented tests
 ```
 
+## Core Priorities
+
+1. Performance first.
+2. Reliability first.
+3. Keep behavior predictable under load and during failures (session restarts, reconnects, partial streams).
+
+If a tradeoff is required, choose correctness and robustness over short-term convenience.
+
+## Maintainability
+
+Long term maintainability is a core priority. If you add new functionality, first check if there is shared logic that can be extracted to a separate module. Duplicate logic across multiple files is a code smell and should be avoided. Don't be afraid to change existing code. Don't take shortcuts by just adding local logic to solve a problem.
+
 ## Architecture & Patterns
 
 - **Clean Architecture**: `data` → `domain` → `presentation` dependency direction.
@@ -41,72 +53,13 @@ app/src/
 - **Navigation**: Single-activity (`MainActivity`) with Compose navigation.
 - **Database**: Room with KSP annotation processing.
 
-## Code Style
-
-- **Kotlin style**: `kotlin.code.style=official` (set in `gradle.properties`).
-- **Formatting**: 4-space indentation; no wildcard imports; Android Studio default ordering (androidx → third-party → project).
-- **Naming**:
-  - Classes/Interfaces: PascalCase (`ShoppingListViewModel`, `ShoppingListRepository`)
-  - Functions/variables: camelCase (`observePendingItems`, `inputValue`)
-  - Use cases: verb phrase (`AddShoppingItemUseCase`, `MarkSelectedItemsPurchasedUseCase`)
-  - Test method names: backtick strings with spaces (`\`adding an item trims input\``)
-- **Types**: Explicit types on public API (interface methods, constructor params); inferred types for local vars and private members.
-- **Nullability**: Non-nullable by default; use `?` only when a value is genuinely optional.
-- **Coroutines**: `suspend` for one-shot operations; `Flow` for reactive streams. Inject `@IoDispatcher` for IO-bound work.
-- **Compose**: Stateful wrapper (`XxxRoute`) calls stateless `XxxScreen`; `modifier` as last default parameter; `testTag` on interactive elements.
-- **Error handling**: Guard clauses with early returns (`if (currentValue.isBlank()) return`). No checked exceptions wrapping.
-
-## Testing Conventions
-
-- **Framework**: JUnit 4 with `@Test`, `@Before`, `@Rule`.
-- **Coroutines**: `runTest { }` for suspend tests; `MainDispatcherRule` to swap `Dispatchers.Main`.
-- **Flow testing**: Turbine (`flow.test { awaitItem() }`) for asserting emitted values.
-- **Fakes over mocks**: `FakeShoppingListRepository` in `testing/` package implements the repository interface in-memory.
-- **Compose UI tests**: `createAndroidComposeRule<MainActivity>()` with `testTag` selectors and `waitUntil` for async state.
-- **Room DAO tests**: Instrumented (`androidTest`), use real in-memory Room database.
-
-## Key Libraries (managed via `gradle/libs.versions.toml`)
-
-Compose BOM `2024.09.00` · Room `2.7.2` · Hilt `2.57` · KSP `2.2.10-2.0.2` · Coroutines `1.10.2` · Turbine `1.2.1` · JaCoCo `0.8.13`
-
 ## Adding New Features
 
-1. Define the domain model in `domain/model/`.
-2. Add repository method signature in `domain/repository/ShoppingListRepository.kt`.
-3. Implement in `data/repository/ShoppingListRepositoryImpl.kt`; add Room migration if schema changes.
-4. Create a use case in `domain/usecase/` — one class, single `operator fun invoke()`.
-5. Add the use case to `ShoppingListViewModel` constructor; wire action method.
-6. Update `ShoppingListUiState` if new UI fields are needed.
-7. Add Compose UI in `ShoppingListScreen.kt`; use `testTag` on interactive elements.
-8. Write unit tests for use case and ViewModel; add Compose UI test if user-facing.
-
-## Dependency Injection Rules
-
-- Bind repository implementations in `di/AppModule.kt` using `@Binds` within an abstract `AppBindModule`.
-- Provide concrete dependencies (database, DAOs, dispatchers) in the `object AppModule` using `@Provides`.
-- ViewModels receive use cases through `@Inject constructor` and are annotated `@HiltViewModel`.
-- Custom qualifiers (e.g. `@IoDispatcher`) live in `core/dispatchers/`.
-
-## Room Database Rules
-
-- Entity classes in `data/local/entity/` use the `Room` annotations.
-- DAOs in `data/local/dao/` return `Flow` for reactive queries, `suspend` for mutations.
-- Mapping between domain models and Room entities is in `data/repository/ShoppingItemMappings.kt`.
-- Database class is in `data/local/db/AppDatabase.kt`.
-
-## Compose UI Guidelines
-
-- Compose screens live in `presentation/shoppinglist/`.
-- `ShoppingListRoute` is the stateful wrapper; `ShoppingListScreen` is stateless.
-- Interactive elements must have `testTag` using constants from `ShoppingListTestTags`.
-- Use `collectAsStateWithLifecycle()` to observe ViewModel state flows.
-- `modifier` parameter goes last with a `Modifier = Modifier` default.
-- Use `stringResource()` for all user-visible strings.
+1. Create a new branch for the feature based on the main
+2. Create atomic commits for each change with a clear description of the changes
+3. Create a pull request with a clear description of the changes
 
 ## Testing Requirements
 
 - Unit test coverage must stay >= 85% (enforced by `verifyDebugCoverage`).
-- Use `FakeShoppingListRepository` for unit tests, not real implementations.
-- Compose UI tests use `createAndroidComposeRule<MainActivity>()` with `testTag` lookups.
-- DAO tests are instrumented (`androidTest`) and use in-memory Room databases.
 - Always run `./gradlew lintDebug` after making changes.

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -107,14 +107,7 @@ fun ShoppingListScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                        Text(text = stringResource(R.string.shopping_list_title))
-                        Text(
-                            text = stringResource(R.string.shopping_list_subtitle),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                    Text(text = stringResource(R.string.shopping_list_title))
                 }
             )
         },
@@ -209,7 +202,6 @@ private fun ShoppingItemsContent(
         item(key = ShoppingListTestTags.PENDING_SECTION) {
             SectionHeader(
                 title = stringResource(R.string.pending_items_title),
-                subtitle = stringResource(R.string.pending_items_subtitle),
                 modifier = Modifier.testTag(ShoppingListTestTags.PENDING_SECTION)
             )
         }
@@ -218,7 +210,6 @@ private fun ShoppingItemsContent(
             item(key = ShoppingListTestTags.EMPTY_STATE) {
                 EmptyStateCard(
                     title = stringResource(R.string.empty_pending_title),
-                    subtitle = stringResource(R.string.empty_pending_subtitle),
                     modifier = Modifier.testTag(ShoppingListTestTags.EMPTY_STATE)
                 )
             }
@@ -243,7 +234,6 @@ private fun ShoppingItemsContent(
         item(key = ShoppingListTestTags.PURCHASED_SECTION) {
             SectionHeader(
                 title = stringResource(R.string.purchased_items_title),
-                subtitle = stringResource(R.string.purchased_items_subtitle),
                 modifier = Modifier.testTag(ShoppingListTestTags.PURCHASED_SECTION)
             )
         }
@@ -251,8 +241,7 @@ private fun ShoppingItemsContent(
         if (uiState.purchasedItems.isEmpty()) {
             item(key = "purchased_empty") {
                 EmptyStateCard(
-                    title = stringResource(R.string.empty_purchased_title),
-                    subtitle = stringResource(R.string.empty_purchased_subtitle)
+                    title = stringResource(R.string.empty_purchased_title)
                 )
             }
         } else {
@@ -299,49 +288,32 @@ private fun DeleteItemDialog(
 @Composable
 private fun SectionHeader(
     title: String,
-    subtitle: String,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(2.dp)
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold
-        )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = modifier.fillMaxWidth()
+    )
 }
 
 @Composable
 private fun EmptyStateCard(
     title: String,
-    subtitle: String,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(20.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp)
+            .padding(20.dp)
     ) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Medium
-        )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }
@@ -419,9 +391,6 @@ private fun PurchasedItemRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-        },
-        supportingContent = {
-            Text(text = stringResource(R.string.restore_to_pending_label))
         },
         leadingContent = {
             Icon(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,24 +1,18 @@
 <resources>
     <string name="app_name">JhowShoppList</string>
     <string name="shopping_list_title">Shopping list</string>
-    <string name="shopping_list_subtitle">Select pending items, then confirm them all at once.</string>
     <string name="add_item_label">Add item</string>
     <string name="add_item_placeholder">Milk, coffee, tomatoes\u2026</string>
     <string name="purchase_selected_items">Mark selected items as purchased</string>
     <string name="pending_items_title">Pending items</string>
-    <string name="pending_items_subtitle">Tap to select what you are buying right now.</string>
     <string name="purchased_items_title">Purchased history</string>
-    <string name="purchased_items_subtitle">Tap an item to send it back to the active list.</string>
     <string name="empty_pending_title">Nothing pending yet</string>
-    <string name="empty_pending_subtitle">Add your first product below to start building the list.</string>
     <string name="empty_purchased_title">No purchase history</string>
-    <string name="empty_purchased_subtitle">Items you complete will stay here for quick reuse.</string>
     <string name="never_purchased_label">Never purchased before</string>
     <plurals name="purchased_count_label">
         <item quantity="one">Purchased %1$d time</item>
         <item quantity="other">Purchased %1$d times</item>
     </plurals>
-    <string name="restore_to_pending_label">Tap to move back to pending</string>
     <string name="delete_item_title">Delete item</string>
     <string name="delete_item_message">Remove %1$s from the local list and queue the deletion for sync?</string>
     <string name="delete_item_confirm">Delete</string>


### PR DESCRIPTION
Removed tutorial text from string resources and Jetpack Compose screens to make the UI more concise and polished.