### PR TITLE
chore: isolate debug deploys from production app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Android Kotlin shopping-list app built with Jetpack Compose, Room, Hilt, and Cle
 | Full coverage report (unit + instrumented) | `./gradlew jacocoFullReport` |
 | Verify coverage threshold (>= 85%) | `./gradlew verifyDebugCoverage` |
 | Lint check | `./gradlew lintDebug` |
+| Deploy debug app to phone | `./scripts/deploy-phone.sh --launch` |
 
 ## Project Structure
 
@@ -63,3 +64,13 @@ Long term maintainability is a core priority. If you add new functionality, firs
 
 - Unit test coverage must stay >= 85% (enforced by `verifyDebugCoverage`).
 - Always run `./gradlew lintDebug` after making changes.
+
+## Deployment Notes
+
+- Production app package: `com.jhow.shopplist`.
+- Debug app package: `com.jhow.shopplist.debug`.
+- Daily-use install is the production app `com.jhow.shopplist`.
+- Debug install is isolated for local testing, adb hooks, and instrumented tests.
+- `./scripts/deploy-phone.sh` always runs `assembleDebug` first, then installs with `adb install -r` so the debug app updates in place without clearing database or app data.
+- The debug launcher label is `JhowShoppList Debug` and uses a different icon color to distinguish it from production.
+- `connectedDebugAndroidTest` targets the debug app only and should not affect the production install.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Corout
 - supports multi-select purchase confirmation
 - tracks purchase frequency for database-driven ordering
 - includes debug hooks for validation through `adb`
+- keeps debug and production installs isolated on-device
 
 ## Architecture
 
@@ -23,6 +24,7 @@ Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Corout
 - `app/src/main/java/com/jhow/shopplist/domain` - models, repository contract, use cases
 - `app/src/main/java/com/jhow/shopplist/presentation` - ViewModel and Compose UI
 - `app/src/debug` - debug-only adb validation receiver
+- `scripts/deploy-phone.sh` - installs debug builds as in-place phone updates
 
 ## Quality gates
 
@@ -37,12 +39,20 @@ Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Corout
 ./gradlew connectedDebugAndroidTest
 ./gradlew verifyDebugCoverage
 ./gradlew lintDebug
+./scripts/deploy-phone.sh --launch
 ```
+
+## Phone deploy behavior
+
+- debug installs use the package `com.jhow.shopplist.debug`
+- production keeps the package `com.jhow.shopplist`
+- instrumented tests target the debug app only, so they do not touch production data
+- `scripts/deploy-phone.sh` installs with `adb install -r`, which updates the debug app without clearing its database or app data
 
 ## adb validation hooks
 
 ```bash
-adb shell am broadcast -a com.jhow.shopplist.debug.RESET_DB -n com.jhow.shopplist/.debug.DebugCommandReceiver
-adb shell am broadcast -a com.jhow.shopplist.debug.SEED_SAMPLE -n com.jhow.shopplist/.debug.DebugCommandReceiver
-adb shell am broadcast -a com.jhow.shopplist.debug.DUMP_STATE -n com.jhow.shopplist/.debug.DebugCommandReceiver
+adb shell am broadcast -a com.jhow.shopplist.debug.RESET_DB -n com.jhow.shopplist.debug/com.jhow.shopplist.debug.DebugCommandReceiver
+adb shell am broadcast -a com.jhow.shopplist.debug.SEED_SAMPLE -n com.jhow.shopplist.debug/com.jhow.shopplist.debug.DebugCommandReceiver
+adb shell am broadcast -a com.jhow.shopplist.debug.DUMP_STATE -n com.jhow.shopplist.debug/com.jhow.shopplist.debug.DebugCommandReceiver
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,12 +19,15 @@ android {
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"
+        testApplicationId = "com.jhow.shopplist.debug.test"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }

--- a/app/src/debug/res/drawable/ic_launcher_background.xml
+++ b/app/src/debug/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#D96A1B"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M9,0L9,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,0L19,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M29,0L29,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,0L39,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M49,0L49,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M59,0L59,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M69,0L69,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M79,0L79,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M89,0L89,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M99,0L99,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,9L108,9"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,19L108,19"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,29L108,29"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,39L108,39"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,49L108,49"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,59L108,59"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,69L108,69"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,79L108,79"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,89L108,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,99L108,99"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,29L89,29"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,39L89,39"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,49L89,49"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,59L89,59"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,69L89,69"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,79L89,79"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M29,19L29,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,19L39,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M49,19L49,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M59,19L59,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M69,19L69,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M79,19L79,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+</vector>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">JhowShoppList Debug</string>
+</resources>

--- a/scripts/deploy-phone.sh
+++ b/scripts/deploy-phone.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APK_PATH="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
+PACKAGE_NAME="com.jhow.shopplist.debug"
+ACTIVITY_NAME="com.jhow.shopplist.MainActivity"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/deploy-phone.sh [--device SERIAL] [--launch]
+
+Builds the debug APK and installs it as a normal update on a connected phone.
+This keeps the debug app's existing database and app data intact.
+
+Options:
+  --device SERIAL  Target a specific adb device serial.
+  --launch         Launch the app after installation.
+  --help           Show this help message.
+EOF
+}
+
+DEVICE_SERIAL="${ANDROID_SERIAL:-}"
+LAUNCH_APP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --device)
+      if [[ $# -lt 2 ]]; then
+        printf 'Missing value for --device\n' >&2
+        exit 1
+      fi
+      DEVICE_SERIAL="$2"
+      shift 2
+      ;;
+    --launch)
+      LAUNCH_APP=true
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+mapfile -t DEVICES < <(adb devices | tail -n +2 | awk '$2 == "device" { print $1 }')
+
+if [[ -z "$DEVICE_SERIAL" ]]; then
+  if [[ ${#DEVICES[@]} -eq 0 ]]; then
+    printf 'No adb device detected. Connect your phone and enable USB debugging.\n' >&2
+    exit 1
+  fi
+
+  if [[ ${#DEVICES[@]} -gt 1 ]]; then
+    printf 'Multiple adb devices detected. Re-run with --device SERIAL.\n' >&2
+    printf 'Available devices:\n' >&2
+    printf '  %s\n' "${DEVICES[@]}" >&2
+    exit 1
+  fi
+
+  DEVICE_SERIAL="${DEVICES[0]}"
+fi
+
+if ! adb -s "$DEVICE_SERIAL" get-state >/dev/null 2>&1; then
+  printf 'Device %s is not available to adb.\n' "$DEVICE_SERIAL" >&2
+  exit 1
+fi
+
+printf 'Building debug APK...\n'
+"$ROOT_DIR/gradlew" assembleDebug
+
+if [[ ! -f "$APK_PATH" ]]; then
+  printf 'Expected APK not found at %s\n' "$APK_PATH" >&2
+  exit 1
+fi
+
+printf 'Installing %s on %s as an in-place update...\n' "$PACKAGE_NAME" "$DEVICE_SERIAL"
+adb -s "$DEVICE_SERIAL" install -r "$APK_PATH"
+
+if [[ "$LAUNCH_APP" == true ]]; then
+  printf 'Launching app...\n'
+  adb -s "$DEVICE_SERIAL" shell am start -n "$PACKAGE_NAME/$ACTIVITY_NAME" >/dev/null
+fi
+
+printf 'Deploy complete. %s was updated without clearing app data.\n' "$PACKAGE_NAME"


### PR DESCRIPTION
## Summary
- isolate the debug build with its own application and test package ids so instrumented tests and phone deploys never touch the production install
- add a `scripts/deploy-phone.sh` helper that rebuilds the latest debug APK and installs it in place with `adb install -r`
- label the debug app as `JhowShoppList Debug`, give it a distinct launcher color, and document the new deployment workflow in `README.md` and `AGENTS.md`

## Verification
- ./gradlew lintDebug
- ./gradlew testDebugUnitTest
- ./gradlew connectedDebugAndroidTest
- ./scripts/deploy-phone.sh --device <serial> --launch