### PR TITLE
Fix shopping list IME flow

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -1,6 +1,7 @@
 package com.jhow.shopplist.presentation.shoppinglist
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -84,6 +85,22 @@ class ShoppingListScreenTest {
     }
 
     @Test
+    fun bulkActionFabFloatsAboveExpandedInputComposer() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performClick()
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("co")
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.SUGGESTION_LIST).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val fabBottom = composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB).fetchSemanticsNode().boundsInRoot.bottom
+        val suggestionTop = composeRule.onNodeWithTag(ShoppingListTestTags.SUGGESTION_LIST).fetchSemanticsNode().boundsInRoot.top
+
+        assertTrue(fabBottom <= suggestionTop)
+    }
+
+    @Test
     fun addingItemFromInputShowsItInPendingList() {
         composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("Yogurt")
         composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performImeAction()
@@ -93,6 +110,18 @@ class ShoppingListScreenTest {
         }
 
         assertTrue(composeRule.onAllNodesWithText("Yogurt").fetchSemanticsNodes().isNotEmpty())
+    }
+
+    @Test
+    fun addingItemFromInputKeepsInputFocusedForContinuousEntry() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("Yogurt")
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performImeAction()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Yogurt").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).assertIsFocused()
     }
 
     @Test
@@ -112,6 +141,24 @@ class ShoppingListScreenTest {
     }
 
     @Test
+    fun overflowingSuggestionListKeepsTopMatchesVisibleNearestTheKeyboard() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("co")
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Coffee")).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Cocoa")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val suggestionListBottom = composeRule.onNodeWithTag(ShoppingListTestTags.SUGGESTION_LIST).fetchSemanticsNode().boundsInRoot.bottom
+        val coffeeBottom = composeRule.onNodeWithTag(ShoppingListTestTags.suggestionItem("Coffee")).fetchSemanticsNode().boundsInRoot.bottom
+        val coffeeTop = composeRule.onNodeWithTag(ShoppingListTestTags.suggestionItem("Coffee")).fetchSemanticsNode().boundsInRoot.top
+        val cocoaTop = composeRule.onNodeWithTag(ShoppingListTestTags.suggestionItem("Cocoa")).fetchSemanticsNode().boundsInRoot.top
+
+        assertTrue(suggestionListBottom - coffeeBottom < 8f)
+        assertTrue(coffeeTop > cocoaTop)
+    }
+
+    @Test
     fun tappingSuggestionReclaimsTheItem() {
         composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("co")
 
@@ -128,6 +175,23 @@ class ShoppingListScreenTest {
         assertTrue(
             composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("purchased-coffee")).fetchSemanticsNodes().isNotEmpty()
         )
+    }
+
+    @Test
+    fun tappingSuggestionKeepsInputFocusedForContinuousEntry() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("co")
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Coffee")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.suggestionItem("Coffee")).performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("purchased-coffee")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).assertIsFocused()
     }
 
     @Test
@@ -203,6 +267,56 @@ class ShoppingListScreenTest {
             purchaseCount = 7,
             createdAt = 1L,
             updatedAt = 2L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "pending-cocoa",
+            name = "Cocoa",
+            isPurchased = false,
+            purchaseCount = 2,
+            createdAt = 1L,
+            updatedAt = 1L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "pending-coconut-milk",
+            name = "Coconut Milk",
+            isPurchased = false,
+            purchaseCount = 3,
+            createdAt = 1L,
+            updatedAt = 1L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "pending-cookie-butter",
+            name = "Cookie Butter",
+            isPurchased = false,
+            purchaseCount = 5,
+            createdAt = 1L,
+            updatedAt = 1L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "pending-cola",
+            name = "Cola",
+            isPurchased = false,
+            purchaseCount = 1,
+            createdAt = 1L,
+            updatedAt = 1L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "pending-cornflakes",
+            name = "Cornflakes",
+            isPurchased = false,
+            purchaseCount = 1,
+            createdAt = 1L,
+            updatedAt = 1L,
             isDeleted = false,
             syncStatus = SyncStatus.SYNCED
         )

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.JhowShoppList"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden|adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -8,12 +8,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,11 +46,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -56,6 +66,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -97,6 +111,11 @@ fun ShoppingListScreen(
     modifier: Modifier = Modifier
 ) {
     val focusManager = LocalFocusManager.current
+    var inputBarContentHeightPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
+    val bulkFabBottomClearance = with(density) {
+        if (inputBarContentHeightPx > 0) inputBarContentHeightPx.toDp() + 16.dp else 88.dp
+    }
 
     LaunchedEffect(Unit) {
         focusManager.clearFocus(force = true)
@@ -105,8 +124,8 @@ fun ShoppingListScreen(
     Scaffold(
         modifier = modifier
             .fillMaxSize()
-            .safeDrawingPadding()
             .testTag(ShoppingListTestTags.SCREEN),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = {
@@ -114,40 +133,37 @@ fun ShoppingListScreen(
                 }
             )
         },
-        bottomBar = {
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            ShoppingItemsContent(
+                uiState = uiState,
+                onPendingItemClick = onPendingItemClick,
+                onPurchasedItemClick = onPurchasedItemClick,
+                onDeleteItemRequested = onDeleteItemRequested,
+                modifier = Modifier.fillMaxSize()
+            )
+
             ShoppingInputBar(
                 value = uiState.inputValue,
                 suggestions = uiState.suggestions,
                 onValueChange = onInputValueChange,
                 onDone = onAddItem,
-                onSuggestionSelected = onSuggestionSelected
+                onSuggestionSelected = onSuggestionSelected,
+                onContentHeightChanged = { inputBarContentHeightPx = it },
+                modifier = Modifier.align(Alignment.BottomCenter)
             )
-        },
-        floatingActionButton = {
-            AnimatedVisibility(
+
+            BulkPurchaseFab(
                 visible = uiState.isBulkActionVisible,
-                enter = fadeIn(),
-                exit = fadeOut()
-            ) {
-                FloatingActionButton(
-                    onClick = onPurchaseSelectedItems,
-                    modifier = Modifier.testTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB)
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Check,
-                        contentDescription = stringResource(R.string.purchase_selected_items)
-                    )
-                }
-            }
+                onClick = onPurchaseSelectedItems,
+                bottomClearance = bulkFabBottomClearance,
+                modifier = Modifier.align(Alignment.BottomEnd)
+            )
         }
-    ) { innerPadding ->
-        ShoppingItemsContent(
-            uiState = uiState,
-            onPendingItemClick = onPendingItemClick,
-            onPurchasedItemClick = onPurchasedItemClick,
-            onDeleteItemRequested = onDeleteItemRequested,
-            modifier = Modifier.padding(innerPadding)
-        )
 
         DeleteItemDialog(
             item = uiState.itemPendingDeletion,
@@ -164,59 +180,117 @@ private fun ShoppingInputBar(
     onValueChange: (String) -> Unit,
     onDone: () -> Unit,
     onSuggestionSelected: (String) -> Unit,
+    onContentHeightChanged: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    fun restoreContinuousEntry() {
+        focusRequester.requestFocus()
+        keyboardController?.show()
+    }
+
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .navigationBarsPadding()
+            .imePadding()
     ) {
-        OutlinedTextField(
-            value = value,
-            onValueChange = onValueChange,
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .testTag(ShoppingListTestTags.INPUT_FIELD),
-            label = { Text(text = stringResource(R.string.add_item_label)) },
-            placeholder = { Text(text = stringResource(R.string.add_item_placeholder)) },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { onDone() }),
-            trailingIcon = {
-                Icon(
-                    imageVector = Icons.Rounded.AddTask,
-                    contentDescription = null
-                )
-            }
-        )
-
-        AnimatedVisibility(visible = suggestions.isNotEmpty()) {
-            Surface(
+                .background(MaterialTheme.colorScheme.surface)
+                .onSizeChanged { onContentHeightChanged(it.height) }
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = onValueChange,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 8.dp)
-                    .testTag(ShoppingListTestTags.SUGGESTION_LIST),
-                shape = RoundedCornerShape(20.dp),
-                color = MaterialTheme.colorScheme.surfaceContainerLow
-            ) {
-                Column {
-                    suggestions.forEachIndexed { index, suggestion ->
-                        if (index > 0) {
-                            HorizontalDivider()
+                    .focusRequester(focusRequester)
+                    .testTag(ShoppingListTestTags.INPUT_FIELD),
+                label = { Text(text = stringResource(R.string.add_item_label)) },
+                placeholder = { Text(text = stringResource(R.string.add_item_placeholder)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        onDone()
+                        restoreContinuousEntry()
+                    }
+                ),
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Rounded.AddTask,
+                        contentDescription = null
+                    )
+                }
+            )
+
+            AnimatedVisibility(visible = suggestions.isNotEmpty()) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp)
+                        .heightIn(max = 176.dp)
+                        .testTag(ShoppingListTestTags.SUGGESTION_LIST),
+                    shape = RoundedCornerShape(20.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerLow
+                ) {
+                    LazyColumn(reverseLayout = true) {
+                        suggestions.forEachIndexed { index, suggestion ->
+                            item(key = suggestion) {
+                                if (index > 0) {
+                                    HorizontalDivider()
+                                }
+                                Text(
+                                    text = suggestion,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .defaultMinSize(minHeight = 56.dp)
+                                        .clickable {
+                                            onSuggestionSelected(suggestion)
+                                            restoreContinuousEntry()
+                                        }
+                                        .padding(horizontal = 16.dp, vertical = 14.dp)
+                                        .testTag(ShoppingListTestTags.suggestionItem(suggestion))
+                                )
+                            }
                         }
-                        Text(
-                            text = suggestion,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onSuggestionSelected(suggestion) }
-                                .padding(horizontal = 16.dp, vertical = 14.dp)
-                                .testTag(ShoppingListTestTags.suggestionItem(suggestion))
-                        )
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun BulkPurchaseFab(
+    visible: Boolean,
+    onClick: () -> Unit,
+    bottomClearance: Dp,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(end = 16.dp, bottom = bottomClearance)
+    ) {
+        FloatingActionButton(
+            onClick = onClick,
+            modifier = Modifier.testTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB)
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = stringResource(R.string.purchase_selected_items)
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep the shopping input and suggestions anchored to the keyboard with explicit inset handling
- float the bulk purchase action above the input composer and keyboard
- add UI coverage for continuous entry, overflowing suggestions, and FAB overlap

## Testing
- ./gradlew lintDebug testDebugUnitTest
- ANDROID_SERIAL=emulator-5554 ./gradlew connectedDebugAndroidTest --console=plain