### PR TITLE
Improve shopping list search matching

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/data/local/dao/ShoppingItemDaoTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/data/local/dao/ShoppingItemDaoTest.kt
@@ -3,6 +3,7 @@ package com.jhow.shopplist.data.local.dao
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.jhow.shopplist.core.search.ShoppingSearch
 import com.jhow.shopplist.data.local.db.AppDatabase
 import com.jhow.shopplist.data.local.entity.ShoppingItemEntity
 import com.jhow.shopplist.domain.model.SyncStatus
@@ -68,25 +69,25 @@ class ShoppingItemDaoTest {
     }
 
     @Test
-    fun findItemByName_returnsMatchingEntity_caseInsensitive() = runBlocking {
+    fun findItemByNormalizedName_returnsMatchingEntity_accentInsensitive() = runBlocking {
         dao.insertItems(
             listOf(
-                entity(id = "pending-milk", name = "Milk"),
-                entity(id = "purchased-milk", name = "MILK", isPurchased = true, purchaseCount = 5)
+                entity(id = "pending-cafe", name = "Café"),
+                entity(id = "purchased-cafe", name = "CAFE", isPurchased = true, purchaseCount = 5)
             )
         )
 
-        val item = dao.findItemByName("milk")
+        val item = dao.findItemByNormalizedName(ShoppingSearch.normalize("cafe"))
 
-        assertEquals("pending-milk", item?.id)
+        assertEquals("pending-cafe", item?.id)
     }
 
     @Test
-    fun findItemByName_returnsNullForDeletedItems() = runBlocking {
-        dao.insertItem(entity(id = "deleted-milk", name = "Milk"))
-        dao.softDeleteItem(id = "deleted-milk", updatedAt = 22)
+    fun findItemByNormalizedName_returnsNullForDeletedItems() = runBlocking {
+        dao.insertItem(entity(id = "deleted-cafe", name = "Café"))
+        dao.softDeleteItem(id = "deleted-cafe", updatedAt = 22)
 
-        val item = dao.findItemByName("milk")
+        val item = dao.findItemByNormalizedName(ShoppingSearch.normalize("cafe"))
 
         assertNull(item)
     }
@@ -106,6 +107,21 @@ class ShoppingItemDaoTest {
         val names = dao.observeAllItemNames().first()
 
         assertEquals(listOf("Beans", "Bread"), names)
+    }
+
+    @Test
+    fun observeAllItemNames_groupsAccentVariantsIntoOneSuggestion() = runBlocking {
+        dao.insertItems(
+            listOf(
+                entity(id = "accented", name = "Café", purchaseCount = 5),
+                entity(id = "plain", name = "Cafe", purchaseCount = 3)
+            )
+        )
+
+        val names = dao.observeAllItemNames().first()
+
+        assertEquals(1, names.size)
+        assertEquals("cafe", ShoppingSearch.normalize(names.single()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -141,6 +141,32 @@ class ShoppingListScreenTest {
     }
 
     @Test
+    fun typingAccentlessQueryShowsAccentedSuggestion() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("cafe")
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Café")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Café")).fetchSemanticsNodes().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun typingFuzzyQueryShowsSubsequenceSuggestion() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("hme")
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Home")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Home")).fetchSemanticsNodes().isNotEmpty()
+        )
+    }
+
+    @Test
     fun overflowingSuggestionListKeepsTopMatchesVisibleNearestTheKeyboard() {
         composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("co")
 
@@ -208,6 +234,25 @@ class ShoppingListScreenTest {
 
         assertTrue(
             composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-apples")).fetchSemanticsNodes().size == 1
+        )
+    }
+
+    @Test
+    fun accentInsensitiveSuggestionSelectionReclaimsTheItem() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("cafe")
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.suggestionItem("Café")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.suggestionItem("Café")).performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("purchased-cafe")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("purchased-cafe")).fetchSemanticsNodes().isNotEmpty()
         )
     }
 
@@ -317,6 +362,26 @@ class ShoppingListScreenTest {
             purchaseCount = 1,
             createdAt = 1L,
             updatedAt = 1L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "pending-home",
+            name = "Home",
+            isPurchased = false,
+            purchaseCount = 6,
+            createdAt = 1L,
+            updatedAt = 1L,
+            isDeleted = false,
+            syncStatus = SyncStatus.SYNCED
+        ),
+        ShoppingItemEntity(
+            id = "purchased-cafe",
+            name = "Café",
+            isPurchased = true,
+            purchaseCount = 4,
+            createdAt = 1L,
+            updatedAt = 2L,
             isDeleted = false,
             syncStatus = SyncStatus.SYNCED
         )

--- a/app/src/main/java/com/jhow/shopplist/core/search/ShoppingSearch.kt
+++ b/app/src/main/java/com/jhow/shopplist/core/search/ShoppingSearch.kt
@@ -1,0 +1,99 @@
+package com.jhow.shopplist.core.search
+
+import java.text.Normalizer
+import java.util.Locale
+
+object ShoppingSearch {
+    private val combiningMarksRegex = "\\p{Mn}+".toRegex()
+
+    fun normalize(text: String): String = Normalizer.normalize(text.trim(), Normalizer.Form.NFD)
+        .replace(combiningMarksRegex, "")
+        .lowercase(Locale.ROOT)
+
+    fun suggestionScore(candidate: String, normalizedQuery: String): Int? {
+        if (normalizedQuery.length < MIN_SUGGESTION_QUERY_LENGTH) {
+            return null
+        }
+
+        val normalizedCandidate = normalize(candidate)
+        if (normalizedCandidate.isEmpty()) {
+            return null
+        }
+
+        if (normalizedCandidate == normalizedQuery) {
+            return EXACT_MATCH_SCORE
+        }
+
+        if (normalizedCandidate.startsWith(normalizedQuery)) {
+            return PREFIX_MATCH_SCORE
+        }
+
+        if (hasWordPrefixMatch(normalizedCandidate, normalizedQuery)) {
+            return WORD_PREFIX_MATCH_SCORE
+        }
+
+        val substringIndex = normalizedCandidate.indexOf(normalizedQuery)
+        if (substringIndex >= 0) {
+            return SUBSTRING_MATCH_SCORE + substringIndex
+        }
+
+        if (normalizedQuery.length < MIN_FUZZY_QUERY_LENGTH) {
+            return null
+        }
+
+        return subsequencePenalty(
+            candidate = normalizedCandidate,
+            query = normalizedQuery
+        )?.let { FUZZY_SUBSEQUENCE_MATCH_SCORE + it }
+    }
+
+    private fun hasWordPrefixMatch(candidate: String, query: String): Boolean {
+        for (index in 1..candidate.lastIndex) {
+            if (!candidate[index - 1].isLetterOrDigit() && candidate.startsWith(query, startIndex = index)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun subsequencePenalty(candidate: String, query: String): Int? {
+        var nextSearchStartIndex = 0
+        var firstMatchIndex = -1
+        var previousMatchIndex = -1
+        var totalGapSize = 0
+
+        for (queryCharacter in query) {
+            val matchIndex = candidate.indexOf(queryCharacter, startIndex = nextSearchStartIndex)
+            if (matchIndex < 0) {
+                return null
+            }
+
+            if (firstMatchIndex < 0) {
+                firstMatchIndex = matchIndex
+            }
+            if (previousMatchIndex >= 0) {
+                totalGapSize += matchIndex - previousMatchIndex - 1
+            }
+
+            previousMatchIndex = matchIndex
+            nextSearchStartIndex = matchIndex + 1
+        }
+
+        val unmatchedTailSize = candidate.length - previousMatchIndex - 1
+        return (firstMatchIndex * FIRST_MATCH_WEIGHT) +
+            (totalGapSize * GAP_WEIGHT) +
+            unmatchedTailSize
+    }
+
+    private const val MIN_SUGGESTION_QUERY_LENGTH = 2
+    private const val MIN_FUZZY_QUERY_LENGTH = 3
+
+    private const val EXACT_MATCH_SCORE = 0
+    private const val PREFIX_MATCH_SCORE = 100
+    private const val WORD_PREFIX_MATCH_SCORE = 200
+    private const val SUBSTRING_MATCH_SCORE = 300
+    private const val FUZZY_SUBSEQUENCE_MATCH_SCORE = 400
+
+    private const val FIRST_MATCH_WEIGHT = 4
+    private const val GAP_WEIGHT = 2
+}

--- a/app/src/main/java/com/jhow/shopplist/data/local/dao/ShoppingItemDao.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/local/dao/ShoppingItemDao.kt
@@ -48,12 +48,12 @@ interface ShoppingItemDao {
     @Query(
         """
         SELECT * FROM items
-        WHERE LOWER(name) = LOWER(:name) AND isDeleted = 0
+        WHERE normalizedName = :normalizedName AND isDeleted = 0
         ORDER BY isPurchased ASC, purchaseCount DESC, updatedAt DESC
         LIMIT 1
         """
     )
-    suspend fun findItemByName(name: String): ShoppingItemEntity?
+    suspend fun findItemByNormalizedName(normalizedName: String): ShoppingItemEntity?
 
     @Query(
         """
@@ -61,7 +61,7 @@ interface ShoppingItemDao {
             SELECT MIN(name) AS displayName, MAX(purchaseCount) AS maxPurchaseCount
             FROM items
             WHERE isDeleted = 0
-            GROUP BY LOWER(name)
+            GROUP BY normalizedName
         )
         ORDER BY maxPurchaseCount DESC, displayName ASC
         """

--- a/app/src/main/java/com/jhow/shopplist/data/local/db/AppDatabase.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/local/db/AppDatabase.kt
@@ -3,12 +3,15 @@ package com.jhow.shopplist.data.local.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.jhow.shopplist.data.local.dao.ShoppingItemDao
 import com.jhow.shopplist.data.local.entity.ShoppingItemEntity
+import com.jhow.shopplist.core.search.ShoppingSearch
 
 @Database(
     entities = [ShoppingItemEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(RoomConverters::class)
@@ -17,5 +20,37 @@ abstract class AppDatabase : RoomDatabase() {
 
     companion object {
         const val DATABASE_NAME: String = "shopping-list.db"
+
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    ALTER TABLE items
+                    ADD COLUMN normalizedName TEXT NOT NULL DEFAULT ''
+                    """.trimIndent()
+                )
+
+                db.query("SELECT id, name FROM items").use { cursor ->
+                    val idColumnIndex = cursor.getColumnIndexOrThrow("id")
+                    val nameColumnIndex = cursor.getColumnIndexOrThrow("name")
+
+                    while (cursor.moveToNext()) {
+                        val id = cursor.getString(idColumnIndex)
+                        val name = cursor.getString(nameColumnIndex)
+                        db.execSQL(
+                            "UPDATE items SET normalizedName = ? WHERE id = ?",
+                            arrayOf(ShoppingSearch.normalize(name), id)
+                        )
+                    }
+                }
+
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS index_items_normalizedName_isDeleted
+                    ON items(normalizedName, isDeleted)
+                    """.trimIndent()
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/data/local/entity/ShoppingItemEntity.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/local/entity/ShoppingItemEntity.kt
@@ -3,18 +3,21 @@ package com.jhow.shopplist.data.local.entity
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.jhow.shopplist.core.search.ShoppingSearch
 import com.jhow.shopplist.domain.model.SyncStatus
 
 @Entity(
     tableName = "items",
     indices = [
         Index(value = ["isPurchased", "isDeleted", "purchaseCount"]),
-        Index(value = ["isPurchased", "isDeleted", "purchaseCount", "updatedAt"])
+        Index(value = ["isPurchased", "isDeleted", "purchaseCount", "updatedAt"]),
+        Index(value = ["normalizedName", "isDeleted"])
     ]
 )
 data class ShoppingItemEntity(
     @PrimaryKey val id: String,
     val name: String,
+    val normalizedName: String = ShoppingSearch.normalize(name),
     val isPurchased: Boolean,
     val purchaseCount: Int,
     val createdAt: Long,

--- a/app/src/main/java/com/jhow/shopplist/data/repository/ShoppingListRepositoryImpl.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/repository/ShoppingListRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.jhow.shopplist.data.repository
 
 import com.jhow.shopplist.core.dispatchers.IoDispatcher
+import com.jhow.shopplist.core.search.ShoppingSearch
 import com.jhow.shopplist.data.local.dao.ShoppingItemDao
 import com.jhow.shopplist.data.local.entity.ShoppingItemEntity
 import com.jhow.shopplist.domain.model.ShoppingItem
@@ -46,7 +47,7 @@ class ShoppingListRepositoryImpl @Inject constructor(
     }
 
     override suspend fun findItemByName(name: String): ShoppingItem? = withContext(ioDispatcher) {
-        shoppingItemDao.findItemByName(name)?.toDomain()
+        shoppingItemDao.findItemByNormalizedName(ShoppingSearch.normalize(name))?.toDomain()
     }
 
     override suspend fun markItemsPurchased(ids: Set<String>) {

--- a/app/src/main/java/com/jhow/shopplist/di/AppModule.kt
+++ b/app/src/main/java/com/jhow/shopplist/di/AppModule.kt
@@ -50,7 +50,9 @@ object AppModule {
     @Provides
     @Singleton
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
-        Room.databaseBuilder(context, AppDatabase::class.java, AppDatabase.DATABASE_NAME).build()
+        Room.databaseBuilder(context, AppDatabase::class.java, AppDatabase.DATABASE_NAME)
+            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .build()
 
     @Provides
     fun provideShoppingItemDao(database: AppDatabase): ShoppingItemDao = database.shoppingItemDao()

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
@@ -2,6 +2,7 @@ package com.jhow.shopplist.presentation.shoppinglist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.jhow.shopplist.core.search.ShoppingSearch
 import com.jhow.shopplist.domain.usecase.AddOrReclaimShoppingItemUseCase
 import com.jhow.shopplist.domain.usecase.DeleteShoppingItemUseCase
 import com.jhow.shopplist.domain.usecase.MarkPurchasedItemPendingUseCase
@@ -133,16 +134,35 @@ class ShoppingListViewModel @Inject constructor(
         const val MAX_SUGGESTION_COUNT = 5
 
         fun buildSuggestions(allItemNames: List<String>, currentInput: String): List<String> {
-            val normalizedInput = currentInput.trim()
+            val normalizedInput = ShoppingSearch.normalize(currentInput)
             if (normalizedInput.length < MIN_SUGGESTION_QUERY_LENGTH) {
                 return emptyList()
             }
 
             return allItemNames
                 .asSequence()
-                .filter { it.contains(normalizedInput, ignoreCase = true) }
+                .mapIndexedNotNull { index, name ->
+                    ShoppingSearch.suggestionScore(
+                        candidate = name,
+                        normalizedQuery = normalizedInput
+                    )?.let { score ->
+                        SuggestionCandidate(
+                            name = name,
+                            originalIndex = index,
+                            score = score
+                        )
+                    }
+                }
+                .sortedWith(compareBy<SuggestionCandidate> { it.score }.thenBy { it.originalIndex })
                 .take(MAX_SUGGESTION_COUNT)
+                .map(SuggestionCandidate::name)
                 .toList()
         }
+
+        private data class SuggestionCandidate(
+            val name: String,
+            val originalIndex: Int,
+            val score: Int
+        )
     }
 }

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
@@ -73,7 +73,40 @@ class ShoppingListViewModelTest {
         viewModel.onInputValueChange("mil")
         advanceUntilIdle()
 
-        assertEquals(listOf("Almond Milk", "Milk"), viewModel.uiState.value.suggestions)
+        assertEquals(listOf("Milk", "Almond Milk"), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `typing shows accent insensitive suggestions`() = runTest {
+        repository.seedItems(
+            listOf(
+                samplePendingItem(id = "cafe", name = "Café"),
+                samplePendingItem(id = "tea", name = "Tea")
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onInputValueChange("cafe")
+        advanceUntilIdle()
+
+        assertEquals(listOf("Café"), viewModel.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `typing shows subsequence fuzzy suggestions`() = runTest {
+        repository.seedItems(
+            listOf(
+                samplePendingItem(id = "home", name = "Home"),
+                samplePendingItem(id = "honey", name = "Honey"),
+                samplePendingItem(id = "bread", name = "Bread")
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onInputValueChange("hme")
+        advanceUntilIdle()
+
+        assertEquals(listOf("Home"), viewModel.uiState.value.suggestions)
     }
 
     @Test
@@ -101,6 +134,34 @@ class ShoppingListViewModelTest {
 
         assertEquals(listOf("beans"), repository.pendingRequests)
         assertEquals(listOf("beans"), viewModel.uiState.value.pendingItems.map { it.id })
+        assertEquals("", viewModel.uiState.value.inputValue)
+    }
+
+    @Test
+    fun `adding an accentless duplicate pending item clears input without adding`() = runTest {
+        repository.seedItems(listOf(samplePendingItem(id = "cafe", name = "Café")))
+        advanceUntilIdle()
+
+        viewModel.onInputValueChange("cafe")
+        viewModel.onAddItem()
+        advanceUntilIdle()
+
+        assertEquals(emptyList<String>(), repository.addedNames)
+        assertEquals("", viewModel.uiState.value.inputValue)
+        assertEquals(1, syncScheduler.requestCount)
+    }
+
+    @Test
+    fun `adding an accentless purchased item reclaims it`() = runTest {
+        repository.seedItems(listOf(samplePurchasedItem(id = "cafe", name = "Café")))
+        advanceUntilIdle()
+
+        viewModel.onInputValueChange("cafe")
+        viewModel.onAddItem()
+        advanceUntilIdle()
+
+        assertEquals(listOf("cafe"), repository.pendingRequests)
+        assertEquals(listOf("cafe"), viewModel.uiState.value.pendingItems.map { it.id })
         assertEquals("", viewModel.uiState.value.inputValue)
     }
 

--- a/app/src/test/java/com/jhow/shopplist/testing/FakeShoppingListRepository.kt
+++ b/app/src/test/java/com/jhow/shopplist/testing/FakeShoppingListRepository.kt
@@ -1,5 +1,6 @@
 package com.jhow.shopplist.testing
 
+import com.jhow.shopplist.core.search.ShoppingSearch
 import com.jhow.shopplist.domain.model.ShoppingItem
 import com.jhow.shopplist.domain.model.ShoppingItemSyncResult
 import com.jhow.shopplist.domain.model.SyncStatus
@@ -28,7 +29,7 @@ class FakeShoppingListRepository : ShoppingListRepository {
             .asSequence()
             .filter { !it.isDeleted }
             .sortedWith(compareByDescending<ShoppingItem> { it.purchaseCount }.thenBy { it.name.lowercase() })
-            .distinctBy { it.name.lowercase() }
+            .distinctBy { ShoppingSearch.normalize(it.name) }
             .map { it.name }
             .toList()
     }
@@ -51,7 +52,7 @@ class FakeShoppingListRepository : ShoppingListRepository {
     override suspend fun findItemByName(name: String): ShoppingItem? =
         items.value
             .asSequence()
-            .filter { !it.isDeleted && it.name.equals(name, ignoreCase = true) }
+            .filter { !it.isDeleted && ShoppingSearch.normalize(it.name) == ShoppingSearch.normalize(name) }
             .sortedWith(compareBy<ShoppingItem> { it.isPurchased }.thenByDescending { it.purchaseCount }.thenByDescending { it.updatedAt })
             .firstOrNull()
 


### PR DESCRIPTION
## Summary
- make shopping search ignore accents and case for suggestions and exact add/reclaim matching
- add fuzzy subsequence ranking so queries like `hme` can surface `Home`
- persist a normalized Room search key with a migration and expand DAO/unit/UI coverage

## Testing
- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- ./gradlew assembleDebug
- ./gradlew assembleDebugAndroidTest
- ./gradlew connectedDebugAndroidTest