### PR TITLE
Add swipe-to-delete for shopping items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ render.experimental.xml
 google-services.json
 *.hprof
 .agents
+skills-lock.json

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jhow.shopplist.MainActivity
@@ -18,6 +20,7 @@ import com.jhow.shopplist.di.DatabaseEntryPoint
 import com.jhow.shopplist.domain.model.SyncStatus
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
+import kotlin.math.abs
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -272,8 +275,15 @@ class ShoppingListScreenTest {
     }
 
     @Test
-    fun deletingPendingItemRemovesItFromVisibleLists() {
-        composeRule.onNodeWithTag(ShoppingListTestTags.deletePendingItem("pending-apples")).performClick()
+    fun swipingPendingItemAndConfirmingRemovesItFromVisibleLists() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.swipePendingItem("pending-apples")).performTouchInput {
+            swipeLeft()
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isNotEmpty()
+        }
+
         composeRule.onNodeWithText("Delete").performClick()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
@@ -286,8 +296,15 @@ class ShoppingListScreenTest {
     }
 
     @Test
-    fun deletingPurchasedItemRemovesItFromHistory() {
-        composeRule.onNodeWithTag(ShoppingListTestTags.deletePurchasedItem("purchased-coffee")).performClick()
+    fun swipingPurchasedItemAndConfirmingRemovesItFromHistory() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.swipePurchasedItem("purchased-coffee")).performTouchInput {
+            swipeLeft()
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isNotEmpty()
+        }
+
         composeRule.onNodeWithText("Delete").performClick()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
@@ -297,6 +314,37 @@ class ShoppingListScreenTest {
         assertTrue(
             composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).fetchSemanticsNodes().isEmpty()
         )
+    }
+
+    @Test
+    fun swipingPendingItemAndCancellingKeepsItVisible() {
+        val initialLeft = composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-bread"))
+            .fetchSemanticsNode().boundsInRoot.left
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.swipePendingItem("pending-bread")).performTouchInput {
+            swipeLeft()
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithText("Cancel").performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isEmpty()
+        }
+
+        composeRule.waitForIdle()
+
+        val restoredLeft = composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-bread"))
+            .fetchSemanticsNode().boundsInRoot.left
+        val tolerance = with(composeRule.density) { 1.dp.toPx() }
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-bread")).fetchSemanticsNodes().isNotEmpty()
+        )
+        assertTrue(abs(restoredLeft - initialLeft) <= tolerance)
     }
 
     private fun sampleItems(): List<ShoppingItemEntity> = listOf(

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AddTask
 import androidx.compose.material.icons.rounded.Check
-import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.RadioButtonUnchecked
 import androidx.compose.material.icons.rounded.Restore
@@ -39,14 +38,16 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -305,6 +306,8 @@ private fun ShoppingItemsContent(
     onDeleteItemRequested: (ShoppingItem) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val swipeResetTrigger = uiState.itemPendingDeletion?.id.orEmpty()
+
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 100.dp),
@@ -333,7 +336,8 @@ private fun ShoppingItemsContent(
                     item = item,
                     isSelected = item.id in uiState.selectedIds,
                     onClick = { onPendingItemClick(item.id) },
-                    onDeleteClick = { onDeleteItemRequested(item) }
+                    onDeleteRequested = { onDeleteItemRequested(item) },
+                    swipeResetTrigger = swipeResetTrigger
                 )
             }
         }
@@ -363,7 +367,8 @@ private fun ShoppingItemsContent(
                 PurchasedItemRow(
                     item = item,
                     onClick = { onPurchasedItemClick(item.id) },
-                    onDeleteClick = { onDeleteItemRequested(item) }
+                    onDeleteRequested = { onDeleteItemRequested(item) },
+                    swipeResetTrigger = swipeResetTrigger
                 )
             }
         }
@@ -434,7 +439,8 @@ private fun PendingItemRow(
     item: ShoppingItem,
     isSelected: Boolean,
     onClick: () -> Unit,
-    onDeleteClick: () -> Unit,
+    onDeleteRequested: () -> Unit,
+    swipeResetTrigger: String,
     modifier: Modifier = Modifier
 ) {
     val containerColor = if (isSelected) {
@@ -447,10 +453,10 @@ private fun PendingItemRow(
         name = item.name,
         leadingIcon = if (isSelected) Icons.Rounded.Check else Icons.Rounded.RadioButtonUnchecked,
         containerColor = containerColor,
-        deleteTag = ShoppingListTestTags.deletePendingItem(item.id),
-        deleteContentDescription = stringResource(R.string.delete_item_content_description, item.name),
         onClick = onClick,
-        onDeleteClick = onDeleteClick,
+        onDeleteRequested = onDeleteRequested,
+        swipeTag = ShoppingListTestTags.swipePendingItem(item.id),
+        swipeResetTrigger = swipeResetTrigger,
         modifier = modifier
             .fillMaxWidth()
             .semantics { contentDescription = item.name }
@@ -462,19 +468,20 @@ private fun PendingItemRow(
 private fun PurchasedItemRow(
     item: ShoppingItem,
     onClick: () -> Unit,
-    onDeleteClick: () -> Unit,
+    onDeleteRequested: () -> Unit,
+    swipeResetTrigger: String,
     modifier: Modifier = Modifier
 ) {
     ShoppingItemRow(
         name = item.name,
         leadingIcon = Icons.Rounded.History,
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        deleteTag = ShoppingListTestTags.deletePurchasedItem(item.id),
-        deleteContentDescription = stringResource(R.string.delete_item_content_description, item.name),
         textDecoration = TextDecoration.LineThrough,
         rowAlpha = 0.6f,
         onClick = onClick,
-        onDeleteClick = onDeleteClick,
+        onDeleteRequested = onDeleteRequested,
+        swipeTag = ShoppingListTestTags.swipePurchasedItem(item.id),
+        swipeResetTrigger = swipeResetTrigger,
         modifier = modifier
             .fillMaxWidth()
             .semantics { contentDescription = item.name }
@@ -487,48 +494,97 @@ private fun ShoppingItemRow(
     name: String,
     leadingIcon: androidx.compose.ui.graphics.vector.ImageVector,
     containerColor: androidx.compose.ui.graphics.Color,
-    deleteTag: String,
-    deleteContentDescription: String,
     onClick: () -> Unit,
-    onDeleteClick: () -> Unit,
+    onDeleteRequested: () -> Unit,
+    swipeTag: String,
+    swipeResetTrigger: String,
     modifier: Modifier = Modifier,
     textDecoration: TextDecoration? = null,
     rowAlpha: Float = 1f
 ) {
-    Row(
-        modifier = modifier
-            .alpha(rowAlpha)
-            .clip(RoundedCornerShape(18.dp))
-            .background(containerColor)
-            .heightIn(min = 56.dp)
-            .padding(start = 16.dp, end = 4.dp)
-            .clickable(onClick = onClick),
-        verticalAlignment = Alignment.CenterVertically
+    val dismissState = rememberSwipeToDismissBoxState()
+
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue == SwipeToDismissBoxValue.EndToStart) {
+            onDeleteRequested()
+            dismissState.reset()
+        }
+    }
+
+    LaunchedEffect(swipeResetTrigger) {
+        if (
+            dismissState.currentValue != SwipeToDismissBoxValue.Settled ||
+                dismissState.targetValue != SwipeToDismissBoxValue.Settled
+        ) {
+            dismissState.reset()
+        }
+    }
+
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            SwipeDeleteBackground(
+                label = stringResource(R.string.delete_item_swipe_label),
+                isActive = dismissState.dismissDirection == SwipeToDismissBoxValue.EndToStart
+            )
+        },
+        modifier = Modifier.testTag(swipeTag)
     ) {
-        Icon(
-            imageVector = leadingIcon,
-            contentDescription = null,
-            modifier = Modifier.size(20.dp)
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Text(
-            text = name,
-            style = MaterialTheme.typography.bodyLarge,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textDecoration = textDecoration,
-            modifier = Modifier
-                .weight(1f)
-                .padding(vertical = 12.dp)
-        )
-        IconButton(
-            onClick = onDeleteClick,
-            modifier = Modifier.testTag(deleteTag)
+        Row(
+            modifier = modifier
+                .alpha(rowAlpha)
+                .clip(RoundedCornerShape(18.dp))
+                .background(containerColor)
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 16.dp)
+                .clickable(onClick = onClick),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                imageVector = Icons.Rounded.DeleteOutline,
-                contentDescription = deleteContentDescription
+                imageVector = leadingIcon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textDecoration = textDecoration,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 12.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun SwipeDeleteBackground(
+    label: String,
+    isActive: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(
+                if (isActive) MaterialTheme.colorScheme.errorContainer
+                else MaterialTheme.colorScheme.surfaceContainerHighest
+            )
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 20.dp),
+        contentAlignment = Alignment.CenterEnd
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = if (isActive) MaterialTheme.colorScheme.onErrorContainer
+            else MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
@@ -15,9 +15,9 @@ object ShoppingListTestTags {
 
     fun purchasedItem(id: String): String = "purchased_item_$id"
 
-    fun deletePendingItem(id: String): String = "delete_pending_item_$id"
+    fun swipePendingItem(id: String): String = "swipe_pending_item_$id"
 
-    fun deletePurchasedItem(id: String): String = "delete_purchased_item_$id"
+    fun swipePurchasedItem(id: String): String = "swipe_purchased_item_$id"
 
     fun suggestionItem(name: String): String = "suggestion_item_$name"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="empty_purchased_title">No purchase history</string>
     <string name="delete_item_title">Delete item</string>
     <string name="delete_item_message">Remove %1$s from the local list and queue the deletion for sync?</string>
+    <string name="delete_item_swipe_label">Delete item</string>
     <string name="delete_item_confirm">Delete</string>
     <string name="delete_item_cancel">Cancel</string>
-    <string name="delete_item_content_description">Delete %1$s</string>
 </resources>


### PR DESCRIPTION
This pull request refactors the item deletion workflow in the shopping list UI from a button-based approach to a swipe-to-delete gesture, improving the user experience and aligning with modern mobile app conventions. It updates both the UI and test code to support swipe-to-delete for pending and purchased items, and adds a new test to verify that cancelling a swipe leaves the item in place.

**UI Refactor: Swipe-to-Delete Implementation**

* Replaces the delete button with a swipe-to-delete gesture using `SwipeToDismissBox` in `ShoppingItemRow`, and adds a custom swipe background label. The delete icon and related content description are removed. [[1]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL490-R540) [[2]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL524-L532) [[3]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL42-R50) [[4]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL437-R443) [[5]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL450-R459) [[6]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL465-R484) [[7]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL366-R371) [[8]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL336-R340) [[9]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bR309-R310) [[10]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL42-R50) [[11]](diffhunk://#diff-18508e17d6fb30b0e8a688cac94b04bc3ab3b01ce1b5c3290f5b0305dbfd9f1bL33) [[12]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R13-L15)
* Updates how test tags are generated for swipe actions, changing from `deletePendingItem`/`deletePurchasedItem` to `swipePendingItem`/`swipePurchasedItem` for better clarity and alignment with the new gesture.

**Testing Updates**

* Refactors existing tests to simulate swipe gestures instead of button clicks for deleting items. Adds usage of `performTouchInput` and `swipeLeft` for gesture simulation in tests. [[1]](diffhunk://#diff-3e7712763860974a2e63e5a5d10b3a2d20f3c8bf2dc90ad2ea689e72bfb8d41aL275-R286) [[2]](diffhunk://#diff-3e7712763860974a2e63e5a5d10b3a2d20f3c8bf2dc90ad2ea689e72bfb8d41aL289-R307) [[3]](diffhunk://#diff-3e7712763860974a2e63e5a5d10b3a2d20f3c8bf2dc90ad2ea689e72bfb8d41aR12-R13)
* Adds a new test (`swipingPendingItemAndCancellingKeepsItVisible`) to verify that cancelling the delete dialog after a swipe restores the item to its original position and keeps it visible. [[1]](diffhunk://#diff-3e7712763860974a2e63e5a5d10b3a2d20f3c8bf2dc90ad2ea689e72bfb8d41aR319-R349) [[2]](diffhunk://#diff-3e7712763860974a2e63e5a5d10b3a2d20f3c8bf2dc90ad2ea689e72bfb8d41aR23)

**Strings and Accessibility**

* Adds a new string resource for the swipe-to-delete label and removes the content description for the old delete button, reflecting the UI changes.

These changes modernize the item deletion workflow, improve test coverage for swipe gestures, and clean up unused code and resources.- Replace delete button with SwipeToDismissBox for pending and purchased items
- Add SwipeDeleteBackground and swipe reset handling
- Update test tags from deletePendingItem/deletePurchasedItem to swipePendingItem/swipePurchasedItem
- Update strings to include delete_item_swipe_label and remove old content description
- Update tests to swipe for delete and to cancel to keep item
- Add skills-lock.json