### PR TITLE
ci: add GitHub-based CI/CD and signed release pipeline

### DIFF
--- a/.github/assets/get-it-on-github.svg
+++ b/.github/assets/get-it-on-github.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="64" viewBox="0 0 220 64" role="img" aria-labelledby="title desc">
+  <title id="title">Get it on GitHub Releases</title>
+  <desc id="desc">Badge linking to GitHub Releases downloads.</desc>
+  <rect width="220" height="64" rx="12" fill="#111827"/>
+  <text x="110" y="24" fill="#9CA3AF" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">Download from</text>
+  <text x="110" y="44" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" text-anchor="middle">GitHub Releases</text>
+</svg>

--- a/.github/assets/track-with-obtainium.svg
+++ b/.github/assets/track-with-obtainium.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="64" viewBox="0 0 220 64" role="img" aria-labelledby="title desc">
+  <title id="title">Track with Obtainium</title>
+  <desc id="desc">Badge linking to the repository for Obtainium tracking.</desc>
+  <rect width="220" height="64" rx="12" fill="#0F766E"/>
+  <text x="110" y="24" fill="#CCFBF1" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">Track updates with</text>
+  <text x="110" y="44" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" text-anchor="middle">Obtainium</text>
+</svg>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot keeps SHA-pinned GitHub Actions and Gradle dependencies updated.
+# Without it, pinned SHAs never receive security patches.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies"
+      - "gradle"
+    open-pull-requests-limit: 5
+    # Group non-breaking updates together so the PR queue stays manageable.
+    groups:
+      androidx:
+        patterns:
+          - "androidx.*"
+      kotlin-and-compose:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "androidx.compose*"
+      test-dependencies:
+        patterns:
+          - "junit*"
+          - "org.mockito*"
+          - "app.cash.turbine*"
+          - "io.mockk*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Run lint
+        run: ./gradlew lintDebug lintRelease
+
+      - name: Build debug and release APKs
+        run: ./gradlew assembleDebug assembleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Make release scripts executable
+        run: chmod +x gradlew scripts/ci/prepare-release-metadata.sh
+
+      - name: Validate release tag
+        run: ./scripts/ci/prepare-release-metadata.sh validate-tag "$GITHUB_REF_NAME" "$GITHUB_WORKSPACE/gradle.properties"
+
+      - name: Validate release secrets
+        env:
+          JHOW_SHOPPLIST_RELEASE_STORE_FILE_BASE64: ${{ secrets.JHOW_SHOPPLIST_RELEASE_STORE_FILE_BASE64 }}
+          JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD: ${{ secrets.JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD }}
+          JHOW_SHOPPLIST_RELEASE_KEY_ALIAS: ${{ secrets.JHOW_SHOPPLIST_RELEASE_KEY_ALIAS }}
+          JHOW_SHOPPLIST_RELEASE_KEY_PASSWORD: ${{ secrets.JHOW_SHOPPLIST_RELEASE_KEY_PASSWORD }}
+        run: |
+          test -n "$JHOW_SHOPPLIST_RELEASE_STORE_FILE_BASE64"
+          test -n "$JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD"
+          test -n "$JHOW_SHOPPLIST_RELEASE_KEY_ALIAS"
+          test -n "$JHOW_SHOPPLIST_RELEASE_KEY_PASSWORD"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Restore release keystore
+        env:
+          JHOW_SHOPPLIST_RELEASE_STORE_FILE_BASE64: ${{ secrets.JHOW_SHOPPLIST_RELEASE_STORE_FILE_BASE64 }}
+          JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD: ${{ secrets.JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD }}
+        run: |
+          # Mask every secret defensively in case a later step logs it.
+          echo "::add-mask::$JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD"
+
+          install -d -m 0700 "$RUNNER_TEMP/release-signing"
+          keystore_path="$RUNNER_TEMP/release-signing/release.keystore"
+          printf '%s' "$JHOW_SHOPPLIST_RELEASE_STORE_FILE_BASE64" | base64 --decode > "$keystore_path"
+          chmod 0600 "$keystore_path"
+
+          # Probe the keystore without exposing the password on the process command line.
+          keytool -list -keystore "$keystore_path" -storepass:env JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD >/dev/null
+
+          echo "JHOW_SHOPPLIST_RELEASE_STORE_FILE=$keystore_path" >> "$GITHUB_ENV"
+
+      - name: Run release validation tasks
+        env:
+          JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD: ${{ secrets.JHOW_SHOPPLIST_RELEASE_STORE_PASSWORD }}
+          JHOW_SHOPPLIST_RELEASE_KEY_ALIAS: ${{ secrets.JHOW_SHOPPLIST_RELEASE_KEY_ALIAS }}
+          JHOW_SHOPPLIST_RELEASE_KEY_PASSWORD: ${{ secrets.JHOW_SHOPPLIST_RELEASE_KEY_PASSWORD }}
+        run: ./gradlew -Pjhow.requireReleaseSigning=true testDebugUnitTest lintRelease assembleRelease
+
+      - name: Verify signed release APK
+        run: ./scripts/ci/prepare-release-metadata.sh verify-apk "$GITHUB_WORKSPACE/app/build/outputs/apk/release/app-release.apk"
+
+      - name: Build verification appendix and checksum
+        run: |
+          ./scripts/ci/prepare-release-metadata.sh build-verification \
+            "$GITHUB_WORKSPACE/app/build/outputs/apk/release/app-release.apk" \
+            "$RUNNER_TEMP/release-verification.md"
+
+          # Write the checksum file next to the APK so it is picked up by the release upload glob.
+          (
+            cd "$GITHUB_WORKSPACE/app/build/outputs/apk/release"
+            sha256sum app-release.apk > app-release.apk.sha256
+          )
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          body_path: ${{ runner.temp }}/release-verification.md
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          files: |
+            app/build/outputs/apk/release/app-release.apk
+            app/build/outputs/apk/release/app-release.apk.sha256
+
+      - name: Remove release keystore
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/release-signing"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # JhowShoppList
 
+[![Release](https://github.com/Jhonattan-Souza/JhowShoppList/actions/workflows/release.yml/badge.svg)](https://github.com/Jhonattan-Souza/JhowShoppList/actions/workflows/release.yml)
+[![Get it on GitHub Releases](.github/assets/get-it-on-github.svg)](https://github.com/Jhonattan-Souza/JhowShoppList/releases)
+[![Track with Obtainium](.github/assets/track-with-obtainium.svg)](https://github.com/Jhonattan-Souza/JhowShoppList)
+
 Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Coroutines, and Flow.
+
+## Install and verify
+
+GitHub Releases is the canonical distribution channel for release APKs.
+
+- Fast install: open the releases page above and download the latest signed APK.
+- Obtainium: add `https://github.com/Jhonattan-Souza/JhowShoppList` as a GitHub source to install and receive updates from GitHub Releases.
+- AppVerifier: use the package name below and the SHA-256 fingerprint published in each signed GitHub Release `Verification` section before installing a downloaded APK.
+
+### Verification info
+
+- Package name: `com.jhow.shopplist`
+- SHA-256 hash of signing certificate: published in each signed GitHub Release `Verification` section
+- Verify a downloaded APK with `apksigner verify --print-certs app-release.apk`
 
 ## What it does
 
@@ -51,15 +69,6 @@ Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Corout
 - instrumented tests target the debug app only, so they do not touch production data
 - `scripts/deploy-debug.sh` installs `com.jhow.shopplist.debug` with `adb install -r`, which updates the debug app without clearing its database or app data
 - `scripts/deploy-release.sh` installs `com.jhow.shopplist` with `adb install -r`, which updates the release app without clearing its database or app data
-
-## Release signing
-
-- Prefer exporting the matching `JHOW_SHOPPLIST_RELEASE_*` environment variables for release signing.
-- If you copy `keystore.properties.example` to `keystore.properties`, keep it local only, store the keystore outside this repository, and delete the file before sharing or archiving the repository directory.
-- `scripts/deploy-release.sh` refuses to run unless all release signing values are present.
-- `./gradlew assembleRelease` can be used without signing secrets for local release-build verification; signed release deployment still requires release signing values.
-- Use a dedicated release keystore for `com.jhow.shopplist`; do not sign the production app with the debug keystore.
-- `./scripts/backup-release-keystore.sh DESTINATION_DIR` creates a timestamped backup containing both the release keystore and `keystore.properties`.
 
 ## Open-source safety
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,47 @@ if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.inputStream().use(keystoreProperties::load)
 }
 
+fun requiredGradleStringProperty(name: String): String {
+    return providers.gradleProperty(name)
+        .orNull
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: error("Missing required Gradle property: $name")
+}
+
+val appVersionName = requiredGradleStringProperty("APP_VERSION_NAME")
+val requireReleaseSigning = providers.gradleProperty("jhow.requireReleaseSigning")
+    .orNull
+    ?.toBooleanStrictOrNull()
+    ?: false
+
+fun deriveVersionCodeFromSemver(versionName: String): Int {
+    val match = Regex("""^(\d+)\.(\d+)\.(\d+)$""")
+        .matchEntire(versionName)
+        ?: error("APP_VERSION_NAME must use MAJOR.MINOR.PATCH semver")
+
+    val (major, minor, patch) = match.destructured
+    val majorPart = major.toInt()
+    val minorPart = minor.toInt()
+    val patchPart = patch.toInt()
+
+    check(minorPart in 0..99 && patchPart in 0..99) {
+        "APP_VERSION_NAME minor and patch values must be between 0 and 99"
+    }
+
+    val derived = (majorPart * 10_000) + (minorPart * 100) + patchPart
+    check(derived > 0) {
+        "APP_VERSION_NAME must be greater than 0.0.0"
+    }
+    return derived
+}
+
+val appVersionCode = deriveVersionCodeFromSemver(appVersionName)
+
+val releaseSigningMissingMessage =
+    "Release signing is not configured. Set releaseStoreFile, releaseStorePassword, releaseKeyAlias, " +
+        "and releaseKeyPassword in keystore.properties or the matching JHOW_SHOPPLIST_RELEASE_* environment variables."
+
 fun signingValue(propertyName: String, envName: String): String? {
     val propertyValue = keystoreProperties.getProperty(propertyName)?.trim().orEmpty()
     if (propertyValue.isNotEmpty()) {
@@ -58,8 +99,8 @@ android {
         applicationId = "com.jhow.shopplist"
         minSdk = 36
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = appVersionCode
+        versionName = appVersionName
         testApplicationId = "com.jhow.shopplist.debug.test"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -86,6 +127,10 @@ android {
             if (hasReleaseSigningConfig) {
                 signingConfig = signingConfigs.getByName("release")
             }
+            // R8/minification is intentionally disabled: enabling it requires validated keep rules
+            // for Room/Hilt/Compose and transitive dependencies (e.g. xpp3 via dav4jvm). The ProGuard
+            // file references are kept so re-enabling isMinifyEnabled later picks up the standard
+            // optimize config plus project-specific rules automatically.
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -125,25 +170,29 @@ android {
     }
 }
 
+val lintVariantTaskNames = setOf("lintDebug", "lintRelease")
+val signingRequiredTaskNames = setOf("bundleRelease", "installRelease")
+
 afterEvaluate {
-    tasks.named("lintDebug") {
-        dependsOn("detekt")
-    }
+    tasks.matching { task -> task.name in lintVariantTaskNames }
+        .configureEach { dependsOn("detekt") }
 }
 
-tasks.matching { task ->
-    task.name in setOf("bundleRelease", "installRelease")
-}.configureEach {
-    doFirst {
-        check(hasReleaseSigningConfig) {
-            "Release signing is not configured. Set releaseStoreFile, releaseStorePassword, releaseKeyAlias, and releaseKeyPassword in keystore.properties or the matching JHOW_SHOPPLIST_RELEASE_* environment variables."
+tasks.matching { task -> task.name in signingRequiredTaskNames }
+    .configureEach {
+        doFirst {
+            check(hasReleaseSigningConfig) { releaseSigningMissingMessage }
         }
     }
-}
 
 tasks.matching { task -> task.name == "assembleRelease" }.configureEach {
+    doFirst {
+        if (requireReleaseSigning) {
+            check(hasReleaseSigningConfig) { releaseSigningMissingMessage }
+        }
+    }
     doLast {
-        if (!hasReleaseSigningConfig) {
+        if (!hasReleaseSigningConfig && !requireReleaseSigning) {
             logger.warn(
                 "assembleRelease completed without release signing. " +
                     "The generated release APK is unsigned and must not be distributed."

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ kotlin.code.style=official
 android.uniquePackageNames=false
 android.dependency.useConstraints=false
 android.r8.strictFullModeForKeepRules=false
+APP_VERSION_NAME=0.1.0

--- a/scripts/ci/prepare-release-metadata.sh
+++ b/scripts/ci/prepare-release-metadata.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/ci/prepare-release-metadata.sh validate-tag <tag> <gradle-properties>
+  scripts/ci/prepare-release-metadata.sh verify-apk <apk-path>
+  scripts/ci/prepare-release-metadata.sh build-verification <apk-path> <output-path>
+EOF
+}
+
+read_property() {
+  local key="$1"
+  local file="$2"
+  local value
+  local match_count
+
+  match_count="$(awk -F= -v key="$key" '
+    {
+      key_part = $1
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", key_part)
+      if (key_part == key) {
+        count++
+      }
+    }
+    END { print count + 0 }
+  ' "$file")"
+
+  if [[ "$match_count" -gt 1 ]]; then
+    printf 'Property %s is defined multiple times in %s\n' "$key" "$file" >&2
+    exit 1
+  fi
+
+  value="$(awk -F= -v key="$key" '
+    {
+      key_part = $1
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", key_part)
+      if (key_part == key) {
+        value = substr($0, index($0, "=") + 1)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      }
+    }
+    END {
+      if (value != "") {
+        print value
+      }
+    }
+  ' "$file" | tr -d '\r')"
+  if [[ -z "$value" ]]; then
+    printf 'Missing property %s in %s\n' "$key" "$file" >&2
+    exit 1
+  fi
+
+  printf '%s' "$value"
+}
+
+validate_tag() {
+  local tag="$1"
+  local properties_file="$2"
+  local version_name
+  local expected_tag
+
+  version_name="$(read_property "APP_VERSION_NAME" "$properties_file")"
+  expected_tag="v${version_name}"
+
+  if [[ "$tag" != "$expected_tag" ]]; then
+    printf 'Tag %s does not match APP_VERSION_NAME %s\n' "$tag" "$version_name" >&2
+    exit 1
+  fi
+}
+
+find_apksigner() {
+  if command -v apksigner >/dev/null 2>&1; then
+    command -v apksigner
+    return
+  fi
+
+  local sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+  local newest=""
+  local candidate
+
+  if [[ -z "$sdk_root" ]]; then
+    printf 'ANDROID_HOME or ANDROID_SDK_ROOT must be set\n' >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  newest="$(printf '%s\n' "$sdk_root"/build-tools/*/apksigner | sort -V | tail -n 1)"
+  shopt -u nullglob
+
+  if [[ -z "$newest" ]]; then
+    printf 'Unable to find apksigner under %s/build-tools\n' "$sdk_root" >&2
+    exit 1
+  fi
+
+  printf '%s' "$newest"
+}
+
+verify_apk() {
+  local apk_path="$1"
+  local apksigner
+
+  if [[ ! -f "$apk_path" ]]; then
+    printf 'Missing APK at %s\n' "$apk_path" >&2
+    exit 1
+  fi
+
+  apksigner="$(find_apksigner)"
+
+  # Fail loudly if the APK is unsigned or the signature is invalid.
+  "$apksigner" verify --verbose "$apk_path" >&2
+}
+
+build_verification() {
+  local apk_path="$1"
+  local output_path="$2"
+  local apksigner
+  local certs_output
+  local digest
+  local apk_sha256
+
+  if [[ ! -f "$apk_path" ]]; then
+    printf 'Missing APK at %s\n' "$apk_path" >&2
+    exit 1
+  fi
+
+  apksigner="$(find_apksigner)"
+
+  # Capture --print-certs output explicitly so apksigner failures abort the script
+  # instead of being swallowed by the pipe.
+  certs_output="$("$apksigner" verify --print-certs "$apk_path")"
+  digest="$(printf '%s\n' "$certs_output" | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' | head -n 1)"
+
+  if [[ -z "$digest" ]]; then
+    printf 'Unable to extract SHA-256 digest from %s\n' "$apk_path" >&2
+    exit 1
+  fi
+
+  apk_sha256="$(sha256sum "$apk_path" | awk '{ print $1 }')"
+
+  cat > "$output_path" <<EOF
+## Verification
+
+- Package name: \`com.jhow.shopplist\`
+- SHA-256 hash of signing certificate: \`$digest\`
+- SHA-256 of \`$(basename "$apk_path")\`: \`$apk_sha256\` (also published as \`$(basename "$apk_path").sha256\`)
+- Verify the signing certificate with \`apksigner verify --print-certs $(basename "$apk_path")\`
+- Verify the APK bytes with \`sha256sum -c $(basename "$apk_path").sha256\`
+- Obtainium source: \`https://github.com/Jhonattan-Souza/JhowShoppList\`
+EOF
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  case "$1" in
+    validate-tag)
+      [[ $# -eq 3 ]] || {
+        usage
+        exit 1
+      }
+      validate_tag "$2" "$3"
+      ;;
+    verify-apk)
+      [[ $# -eq 2 ]] || {
+        usage
+        exit 1
+      }
+      verify_apk "$2"
+      ;;
+    build-verification)
+      [[ $# -eq 3 ]] || {
+        usage
+        exit 1
+      }
+      build_verification "$2" "$3"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a complete GitHub-based CI/CD pipeline for the JhowShoppList Android app, including PR validation, signed release builds published to GitHub Releases, and verification metadata for Obtainium + AppVerifier users.

## Changes

- **Centralized versioning**: `APP_VERSION_NAME` in `gradle.properties` is the single source of truth; `versionCode` is auto-derived from semver
- **CI workflow**: runs `testDebugUnitTest`, `lintDebug`, `lintRelease`, `assembleDebug`, `assembleRelease` on every PR and `main` push
- **Release workflow**: tag-driven (`v*.*.*`), validates tag/version alignment, reconstructs signing keystore from secrets, builds signed release APK, publishes to GitHub Releases with verification appendix
- **Security hardening**: SHA-pinned Actions, `::add-mask::`, `-storepass:env`, `chmod 600/700` on keystore, explicit `apksigner verify`, `always()` cleanup
- **Verification metadata**: per-release SHA-256 signing certificate fingerprint + APK checksum file published alongside the APK
- **Dependabot**: weekly updates for `github-actions` and `gradle` with grouped PRs
- **README updates**: Obtainium install guidance, AppVerifier verification workflow, self-hosted badges

## Checklist

- [x] `./gradlew testDebugUnitTest lintDebug lintRelease assembleDebug assembleRelease` passes locally
- [x] `./scripts/ci/prepare-release-metadata.sh validate-tag v0.1.0 gradle.properties` passes
- [x] Actions are SHA-pinned with version comments
- [x] Release workflow fails fast if tag does not match `APP_VERSION_NAME`
- [x] Release workflow fails fast if signing secrets are missing

## Post-merge setup required

1. Configure GitHub secrets (see PR description comment below)
2. Push tag `v0.1.0` after merge to validate the release pipeline end-to-end

## Related

Closes #1