### PR TITLE
docs: add Obtainium badge and standardize SHA-256 fingerprint format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # JhowShoppList
 
 [![Release](https://github.com/Jhonattan-Souza/JhowShoppList/actions/workflows/release.yml/badge.svg)](https://github.com/Jhonattan-Souza/JhowShoppList/actions/workflows/release.yml)
-[![Get it on GitHub Releases](.github/assets/get-it-on-github.svg)](https://github.com/Jhonattan-Souza/JhowShoppList/releases)
-[![Track with Obtainium](.github/assets/track-with-obtainium.svg)](https://github.com/Jhonattan-Souza/JhowShoppList)
 
 Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Coroutines, and Flow.
 
-## Install and verify
+## Installation
+
+[![Get it on GitHub Releases](.github/assets/get-it-on-github.svg)](https://github.com/Jhonattan-Souza/JhowShoppList/releases)
+[![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png)](https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22com.jhow.shopplist%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FJhonattan-Souza%2FJhowShoppList%22%2C%22author%22%3A%22Jhonattan-Souza%22%2C%22name%22%3A%22JhowShoppList%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Afalse%2C%5C%22fallbackToOlderReleases%5C%22%3Atrue%2C%5C%22verifyLatestTag%5C%22%3Atrue%2C%5C%22versionDetection%5C%22%3Atrue%2C%5C%22autoApkFilterByArch%5C%22%3Atrue%2C%5C%22appName%5C%22%3A%5C%22JhowShoppList%5C%22%2C%5C%22shizukuPretendToBeGooglePlay%5C%22%3Afalse%2C%5C%22allowInsecure%5C%22%3Afalse%2C%5C%22exemptFromBackgroundUpdates%5C%22%3Afalse%2C%5C%22skipUpdateNotifications%5C%22%3Afalse%2C%5C%22refreshBeforeDownload%5C%22%3Atrue%7D%22%7D)
 
 GitHub Releases is the canonical distribution channel for release APKs.
 
 - Fast install: open the releases page above and download the latest signed APK.
-- Obtainium: add `https://github.com/Jhonattan-Souza/JhowShoppList` as a GitHub source to install and receive updates from GitHub Releases.
-- AppVerifier: use the package name below and the SHA-256 fingerprint published in each signed GitHub Release `Verification` section before installing a downloaded APK.
+- Obtainium: click the badge above or add `https://github.com/Jhonattan-Souza/JhowShoppList` as a GitHub source to install and receive updates from GitHub Releases.
+- AppVerifier: use the package name below and the SHA-256 fingerprint before installing a downloaded APK.
 
-### Verification info
+Verification info:
 
-- Package name: `com.jhow.shopplist`
-- SHA-256 hash of signing certificate: published in each signed GitHub Release `Verification` section
+- Package ID: `com.jhow.shopplist`
+- SHA-256 hash of signing certificate: `E1:61:7B:4A:4A:98:B1:CE:33:7D:CF:23:69:EB:99:E7:18:46:E4:B0:D0:6E:37:5D:3E:42:F7:73:40:6E:DC:0D`
+    - Note: This signature is valid for all GitHub Release APKs.
 - Verify a downloaded APK with `apksigner verify --print-certs app-release.apk`
 
 ## What it does

--- a/scripts/ci/prepare-release-metadata.sh
+++ b/scripts/ci/prepare-release-metadata.sh
@@ -134,6 +134,7 @@ build_verification() {
     exit 1
   fi
   digest="$(printf '%s\n' "$certs_output" | sed -n 's/^.*certificate SHA-256 digest: //p' | head -n 1)"
+  digest="$(printf '%s\n' "$digest" | tr 'a-f' 'A-F' | sed 's/../&:/g; s/:$//')"
 
   if [[ -z "$digest" ]]; then
     printf 'Unable to extract SHA-256 digest from %s\n' "$apk_path" >&2


### PR DESCRIPTION
## Summary

This PR updates the README and release metadata to match the Obtainium project's style for app distribution and certificate verification.

### Changes

- **README.md**:
  - Added official Obtainium badge with direct app-config redirect link
  - Restructured install section to match Obtainium's format
  - Updated SHA-256 fingerprint to colon-separated uppercase format
  - Added verification note about signature validity

- **scripts/ci/prepare-release-metadata.sh**:
  - Auto-formats the signing certificate SHA-256 digest as colon-separated uppercase in future releases

### Why

The colon-separated uppercase format is the industry standard for certificate fingerprints (used by `apksigner`, `keytool`, Android Studio, etc.). It improves human readability and makes visual comparison with tool output easier.