### PR TITLE
fix(sync): implement real CalDAV bidirectional sync with merge and scheduling reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,12 @@ service-account*.json
 secrets.properties
 secrets.*.properties
 
+# Kotlin
+.kotlin/
+
+## LLM docs and tests
 .agents
 skills-lock.json
 .opencode
-docs
 .superpowers
+.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,17 @@ Long term maintainability is a core priority. If you add new functionality, firs
 - `./scripts/backup-release-keystore.sh DESTINATION_DIR` creates a secure local backup of the release keystore plus `keystore.properties`.
 - The debug launcher label is `Jhow Shopp List Debug` and uses a different icon color to distinguish it from production.
 - `connectedDebugAndroidTest` targets the debug app only and should not affect the production install.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles mapped to GitHub labels as listed below. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListPullRefreshTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListPullRefreshTest.kt
@@ -86,7 +86,7 @@ class ShoppingListPullRefreshTest {
     }
 
     @Test
-    fun pullToRefreshSpinner_notShown_whenIsSyncingFalse() {
+    fun pullToRefreshSpinner_remainsAvailable_whenIsSyncingFalse() {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(isSyncing = false),
@@ -95,6 +95,6 @@ class ShoppingListPullRefreshTest {
         }
         composeRule.waitForIdle()
 
-        composeRule.onNodeWithTag(ShoppingListTestTags.PULL_REFRESH_SPINNER).assertDoesNotExist()
+        composeRule.onNodeWithTag(ShoppingListTestTags.PULL_REFRESH_SPINNER).assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/data/repository/ShoppingListRepositoryImpl.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/repository/ShoppingListRepositoryImpl.kt
@@ -91,30 +91,12 @@ class ShoppingListRepositoryImpl @Inject constructor(
         if (items.isEmpty()) return
         withContext(ioDispatcher) {
             val now = System.currentTimeMillis()
-            val knownRemoteUids = shoppingItemDao.getAllItems()
-                .mapNotNull { it.remoteUid }
-                .toSet()
-            val newItems = items.filter { it.remoteUid !in knownRemoteUids }
-            if (newItems.isEmpty()) return@withContext
-            shoppingItemDao.insertItems(
-                newItems.map { remote ->
-                    ShoppingItemEntity(
-                        id = UUID.randomUUID().toString(),
-                        name = remote.summary,
-                        isPurchased = remote.isCompleted,
-                        purchaseCount = if (remote.isCompleted) 1 else 0,
-                        createdAt = remote.lastModifiedAt ?: now,
-                        updatedAt = remote.lastModifiedAt ?: now,
-                        isDeleted = false,
-                        syncStatus = SyncStatus.SYNCED,
-                        remoteUid = remote.remoteUid,
-                        remoteHref = remote.href,
-                        remoteEtag = remote.eTag,
-                        remoteLastModifiedAt = remote.lastModifiedAt,
-                        lastSyncedAt = now
-                    )
+            val existingByRemoteUid = shoppingItemDao.getAllItems()
+                .mapNotNull { existing ->
+                    existing.remoteUid?.let { remoteUid -> remoteUid to existing }
                 }
-            )
+                .toMap()
+            shoppingItemDao.insertItems(items.map { remote -> remote.toEntity(existingByRemoteUid[remote.remoteUid], now) })
         }
     }
 
@@ -133,4 +115,43 @@ class ShoppingListRepositoryImpl @Inject constructor(
             )
         }
     }
+
+    private fun RemoteShoppingItemSnapshot.toEntity(
+        existing: ShoppingItemEntity?,
+        now: Long
+    ): ShoppingItemEntity = existing?.mergeRemote(this, now) ?: ShoppingItemEntity(
+        id = UUID.randomUUID().toString(),
+        name = summary,
+        isPurchased = isCompleted,
+        purchaseCount = if (isCompleted) 1 else 0,
+        createdAt = lastModifiedAt ?: now,
+        updatedAt = lastModifiedAt ?: now,
+        isDeleted = false,
+        syncStatus = SyncStatus.SYNCED,
+        remoteUid = remoteUid,
+        remoteHref = href,
+        remoteEtag = eTag,
+        remoteLastModifiedAt = lastModifiedAt,
+        lastSyncedAt = now
+    )
+
+    private fun ShoppingItemEntity.mergeRemote(
+        remote: RemoteShoppingItemSnapshot,
+        now: Long
+    ): ShoppingItemEntity = copy(
+        name = remote.summary,
+        normalizedName = ShoppingSearch.normalize(remote.summary),
+        isPurchased = remote.isCompleted,
+        purchaseCount = updatedPurchaseCount(remote.isCompleted),
+        updatedAt = remote.lastModifiedAt ?: now,
+        isDeleted = false,
+        syncStatus = SyncStatus.SYNCED,
+        remoteHref = remote.href,
+        remoteEtag = remote.eTag,
+        remoteLastModifiedAt = remote.lastModifiedAt,
+        lastSyncedAt = now
+    )
+
+    private fun ShoppingItemEntity.updatedPurchaseCount(isCompletedRemotely: Boolean): Int =
+        if (isCompletedRemotely && !isPurchased) purchaseCount + 1 else purchaseCount
 }

--- a/app/src/main/java/com/jhow/shopplist/data/sync/CalDavDiscoveryService.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/sync/CalDavDiscoveryService.kt
@@ -1,6 +1,18 @@
 package com.jhow.shopplist.data.sync
 
 import com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot
+import com.jhow.shopplist.domain.model.ShoppingItem
+
+data class CalDavTaskUpsertResult(
+    val remoteUid: String,
+    val href: String,
+    val eTag: String?,
+    val lastModifiedAt: Long?
+)
+
+data class CalDavTaskDeleteResult(
+    val deletedAt: Long?
+)
 
 interface CalDavDiscoveryService {
     suspend fun findTaskCollections(
@@ -22,4 +34,20 @@ interface CalDavDiscoveryService {
         password: String,
         collectionHref: String
     ): List<RemoteShoppingItemSnapshot>
+
+    suspend fun upsertTaskItem(
+        serverUrl: String,
+        username: String,
+        password: String,
+        collectionHref: String,
+        item: ShoppingItem
+    ): CalDavTaskUpsertResult
+
+    suspend fun deleteTaskItem(
+        serverUrl: String,
+        username: String,
+        password: String,
+        href: String,
+        eTag: String?
+    ): CalDavTaskDeleteResult
 }

--- a/app/src/main/java/com/jhow/shopplist/data/sync/CalDavSyncExecutor.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/sync/CalDavSyncExecutor.kt
@@ -3,7 +3,6 @@ package com.jhow.shopplist.data.sync
 import com.jhow.shopplist.domain.model.CalDavSyncOutcome
 import com.jhow.shopplist.domain.model.ShoppingItemSyncResult
 import com.jhow.shopplist.domain.repository.ShoppingListRepository
-import java.util.UUID
 import javax.inject.Inject
 
 class CalDavSyncExecutor @Inject constructor(
@@ -25,30 +24,103 @@ class CalDavSyncExecutor @Inject constructor(
             collectionHref = collectionHref
         )
         val plan = planner.plan(localItems, remoteItems)
-
-        if (plan.itemsToImport.isNotEmpty()) {
-            repository.importRemoteItems(plan.itemsToImport)
-        }
-
-        if (plan.remoteUidsToDeleteLocally.isNotEmpty()) {
-            repository.applyRemoteDeletes(plan.remoteUidsToDeleteLocally)
-        }
+        applyRemoteChangesLocally(plan)
 
         val now = System.currentTimeMillis()
-        val syncedResults = plan.itemsToPush.map { item ->
-            ShoppingItemSyncResult(
-                id = item.id,
-                serverUpdatedAt = now,
-                remoteUid = item.remoteMetadata.remoteUid ?: UUID.randomUUID().toString(),
-                remoteHref = "$collectionHref/${item.id}.ics",
-                remoteEtag = "\"etag-${item.id}\"",
-                lastSyncedAt = now
-            )
+        val remoteByUid = remoteItems.associateBy { it.remoteUid }
+        val syncedResults = buildList {
+            addAll(markDeletesAlreadySynced(plan.itemsToMarkSynced, now))
+            addAll(pushPendingItems(plan.itemsToPush, serverUrl, username, password, collectionHref, now))
+            addAll(deletePendingItems(plan.itemsToDeleteRemotely, remoteByUid, serverUrl, username, password, now))
         }
 
         return CalDavSyncOutcome.Success(
             syncedResults = syncedResults,
             importedCount = plan.itemsToImport.size
+        )
+    }
+
+    private suspend fun applyRemoteChangesLocally(plan: CalDavSyncPlan) {
+        val remoteItemsToApplyLocally = plan.itemsToImport + plan.itemsToUpdateLocally
+        if (remoteItemsToApplyLocally.isNotEmpty()) {
+            repository.importRemoteItems(remoteItemsToApplyLocally)
+        }
+
+        if (plan.remoteUidsToDeleteLocally.isNotEmpty()) {
+            repository.applyRemoteDeletes(plan.remoteUidsToDeleteLocally)
+        }
+    }
+
+    private fun markDeletesAlreadySynced(
+        items: List<com.jhow.shopplist.domain.model.ShoppingItem>,
+        now: Long
+    ): List<ShoppingItemSyncResult> =
+        items.map { item ->
+            ShoppingItemSyncResult(
+                id = item.id,
+                serverUpdatedAt = now,
+                remoteUid = item.remoteMetadata.remoteUid,
+                remoteHref = item.remoteMetadata.remoteHref,
+                remoteEtag = item.remoteMetadata.remoteEtag,
+                remoteLastModifiedAt = item.remoteMetadata.remoteLastModifiedAt,
+                lastSyncedAt = now
+            )
+        }
+
+    private suspend fun pushPendingItems(
+        items: List<com.jhow.shopplist.domain.model.ShoppingItem>,
+        serverUrl: String,
+        username: String,
+        password: String,
+        collectionHref: String,
+        now: Long
+    ): List<ShoppingItemSyncResult> = items.map { item ->
+        val result = discoveryService.upsertTaskItem(
+            serverUrl = serverUrl,
+            username = username,
+            password = password,
+            collectionHref = collectionHref,
+            item = item
+        )
+        ShoppingItemSyncResult(
+            id = item.id,
+            serverUpdatedAt = result.lastModifiedAt ?: now,
+            remoteUid = result.remoteUid,
+            remoteHref = result.href,
+            remoteEtag = result.eTag,
+            remoteLastModifiedAt = result.lastModifiedAt,
+            lastSyncedAt = now
+        )
+    }
+
+    private suspend fun deletePendingItems(
+        items: List<com.jhow.shopplist.domain.model.ShoppingItem>,
+        remoteByUid: Map<String, com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot>,
+        serverUrl: String,
+        username: String,
+        password: String,
+        now: Long
+    ): List<ShoppingItemSyncResult> = items.map { item ->
+        val remote = item.remoteMetadata.remoteUid?.let(remoteByUid::get)
+        val href = item.remoteMetadata.remoteHref ?: remote?.href
+            ?: error("Cannot delete remote item without href for ${item.id}")
+        val eTag = remote?.eTag ?: item.remoteMetadata.remoteEtag
+        val result = discoveryService.deleteTaskItem(
+            serverUrl = serverUrl,
+            username = username,
+            password = password,
+            href = href,
+            eTag = eTag
+        )
+        ShoppingItemSyncResult(
+            id = item.id,
+            serverUpdatedAt = result.deletedAt ?: now,
+            remoteUid = item.remoteMetadata.remoteUid,
+            remoteHref = href,
+            remoteEtag = null,
+            remoteLastModifiedAt = null,
+            lastSyncedAt = now,
+            deletedRemotely = true
         )
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/data/sync/CalDavSyncPlanner.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/sync/CalDavSyncPlanner.kt
@@ -7,7 +7,10 @@ import javax.inject.Inject
 
 data class CalDavSyncPlan(
     val itemsToPush: List<ShoppingItem>,
+    val itemsToDeleteRemotely: List<ShoppingItem>,
     val itemsToImport: List<RemoteShoppingItemSnapshot>,
+    val itemsToUpdateLocally: List<RemoteShoppingItemSnapshot>,
+    val itemsToMarkSynced: List<ShoppingItem>,
     val remoteUidsToDeleteLocally: Set<String>
 )
 
@@ -18,17 +21,90 @@ class CalDavSyncPlanner @Inject constructor() {
             local.remoteMetadata.remoteUid?.let { remoteUid -> remoteUid to local }
         }.toMap()
 
-        val itemsToPush = localItems.filter { local ->
-            local.syncStatus != SyncStatus.SYNCED
-        }
-
-        val itemsToImport = remoteItems.filter { remote -> remote.remoteUid !in localByUid }
-        val remoteUidsToDeleteLocally = localByUid.keys - remoteByUid.keys
-
         return CalDavSyncPlan(
-            itemsToPush = itemsToPush,
-            itemsToImport = itemsToImport,
-            remoteUidsToDeleteLocally = remoteUidsToDeleteLocally
+            itemsToPush = pendingItemsToPush(localItems, remoteByUid),
+            itemsToDeleteRemotely = pendingItemsToDeleteRemotely(localItems, remoteByUid),
+            itemsToImport = remoteItems.filter { remote -> remote.remoteUid !in localByUid },
+            itemsToUpdateLocally = remoteItemsToUpdateLocally(remoteItems, localByUid),
+            itemsToMarkSynced = pendingDeletesToMarkSynced(localItems, remoteByUid),
+            remoteUidsToDeleteLocally = remoteDeletesToApplyLocally(localItems, remoteByUid)
         )
     }
+
+    private fun pendingItemsToPush(
+        localItems: List<ShoppingItem>,
+        remoteByUid: Map<String, RemoteShoppingItemSnapshot>
+    ): List<ShoppingItem> = localItems.filter { local ->
+        when (local.syncStatus) {
+            SyncStatus.PENDING_INSERT,
+            SyncStatus.PENDING_UPDATE -> {
+                val remote = local.remoteMetadata.remoteUid?.let(remoteByUid::get)
+                remote == null || !shouldApplyRemoteUpdate(local, remote)
+            }
+
+            SyncStatus.PENDING_DELETE,
+            SyncStatus.SYNCED -> false
+        }
+    }
+
+    private fun remoteItemsToUpdateLocally(
+        remoteItems: List<RemoteShoppingItemSnapshot>,
+        localByUid: Map<String, ShoppingItem>
+    ): List<RemoteShoppingItemSnapshot> = remoteItems.filter { remote ->
+        val local = localByUid[remote.remoteUid] ?: return@filter false
+        when (local.syncStatus) {
+            SyncStatus.SYNCED -> remoteDiffersFromLocal(local, remote)
+            SyncStatus.PENDING_INSERT,
+            SyncStatus.PENDING_UPDATE -> shouldApplyRemoteUpdate(local, remote)
+            SyncStatus.PENDING_DELETE -> false
+        }
+    }
+
+    private fun pendingItemsToDeleteRemotely(
+        localItems: List<ShoppingItem>,
+        remoteByUid: Map<String, RemoteShoppingItemSnapshot>
+    ): List<ShoppingItem> = localItems.filter { local ->
+        local.syncStatus == SyncStatus.PENDING_DELETE &&
+            local.remoteMetadata.remoteUid?.let(remoteByUid::containsKey) == true
+    }
+
+    private fun pendingDeletesToMarkSynced(
+        localItems: List<ShoppingItem>,
+        remoteByUid: Map<String, RemoteShoppingItemSnapshot>
+    ): List<ShoppingItem> = localItems.filter { local ->
+        local.syncStatus == SyncStatus.PENDING_DELETE &&
+            local.remoteMetadata.remoteUid?.let(remoteByUid::containsKey) != true
+    }
+
+    private fun remoteDeletesToApplyLocally(
+        localItems: List<ShoppingItem>,
+        remoteByUid: Map<String, RemoteShoppingItemSnapshot>
+    ): Set<String> = localItems.mapNotNull { local ->
+        val remoteUid = local.remoteMetadata.remoteUid ?: return@mapNotNull null
+        remoteUid.takeIf {
+            local.syncStatus == SyncStatus.SYNCED &&
+                remoteUid !in remoteByUid
+        }
+    }.toSet()
+
+    private fun shouldApplyRemoteUpdate(
+        local: ShoppingItem,
+        remote: RemoteShoppingItemSnapshot
+    ): Boolean {
+        val remoteLastModifiedAt = remote.lastModifiedAt ?: return false
+        val localKnownRemoteAt = local.remoteMetadata.remoteLastModifiedAt
+            ?: local.remoteMetadata.lastSyncedAt
+            ?: return false
+        return remoteLastModifiedAt > localKnownRemoteAt && remoteLastModifiedAt > local.updatedAt
+    }
+
+    private fun remoteDiffersFromLocal(
+        local: ShoppingItem,
+        remote: RemoteShoppingItemSnapshot
+    ): Boolean =
+        local.name != remote.summary ||
+            local.isPurchased != remote.isCompleted ||
+            local.remoteMetadata.remoteHref != remote.href ||
+            local.remoteMetadata.remoteEtag != remote.eTag ||
+            local.remoteMetadata.remoteLastModifiedAt != remote.lastModifiedAt
 }

--- a/app/src/main/java/com/jhow/shopplist/data/sync/Dav4jvmCalDavDiscoveryService.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/sync/Dav4jvmCalDavDiscoveryService.kt
@@ -8,8 +8,11 @@ import at.bitfire.dav4jvm.exception.UnauthorizedException
 import at.bitfire.dav4jvm.property.DisplayName
 import at.bitfire.dav4jvm.property.ResourceType
 import com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot
+import com.jhow.shopplist.domain.model.ShoppingItem
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.xml.parsers.DocumentBuilderFactory
@@ -17,6 +20,7 @@ import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Request
 import org.w3c.dom.Element
@@ -121,6 +125,78 @@ class Dav4jvmCalDavDiscoveryService @Inject constructor(
         return responseBody.parseTaskItems(collectionUrl = collectionUrl)
     }
 
+    override suspend fun upsertTaskItem(
+        serverUrl: String,
+        username: String,
+        password: String,
+        collectionHref: String,
+        item: ShoppingItem
+    ): CalDavTaskUpsertResult {
+        val collectionUrl = serverUrl.resolveCollectionUrl(collectionHref)
+        val payload = mapper.toVTodo(item)
+        val itemUrl = item.remoteMetadata.remoteHref
+            ?.let(serverUrl::resolveItemUrl)
+            ?: requireNotNull(collectionUrl.resolve("${payload.uid}.ics")) {
+                "Invalid task item URL"
+            }
+
+        return httpClient(username, password)
+            .newCall(
+                Request.Builder()
+                    .url(itemUrl)
+                    .apply {
+                        item.remoteMetadata.remoteEtag?.let { header("If-Match", it) }
+                    }
+                    .method("PUT", payload.body.toRequestBody(TEXT_CALENDAR_MEDIA_TYPE))
+                    .build()
+            )
+            .execute()
+            .use { response ->
+                when (response.code) {
+                    HTTP_OK, HTTP_CREATED, HTTP_NO_CONTENT -> CalDavTaskUpsertResult(
+                        remoteUid = payload.uid,
+                        href = itemUrl.toString(),
+                        eTag = response.header("ETag") ?: item.remoteMetadata.remoteEtag,
+                        lastModifiedAt = response.header("Last-Modified")?.parseHttpDate() ?: item.updatedAt
+                    )
+
+                    HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> throw CalDavAuthenticationException()
+                    else -> error("PUT failed with HTTP ${response.code}")
+                }
+            }
+    }
+
+    override suspend fun deleteTaskItem(
+        serverUrl: String,
+        username: String,
+        password: String,
+        href: String,
+        eTag: String?
+    ): CalDavTaskDeleteResult {
+        val itemUrl = serverUrl.resolveItemUrl(href)
+        return httpClient(username, password)
+            .newCall(
+                Request.Builder()
+                    .url(itemUrl)
+                    .apply {
+                        eTag?.let { header("If-Match", it) }
+                    }
+                    .delete()
+                    .build()
+            )
+            .execute()
+            .use { response ->
+                when (response.code) {
+                    HTTP_OK, HTTP_ACCEPTED, HTTP_NO_CONTENT, HTTP_NOT_FOUND -> CalDavTaskDeleteResult(
+                        deletedAt = response.header("Last-Modified")?.parseHttpDate()
+                    )
+
+                    HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> throw CalDavAuthenticationException()
+                    else -> error("DELETE failed with HTTP ${response.code}")
+                }
+            }
+    }
+
     private fun httpClient(username: String, password: String): OkHttpClient {
         val authHandler = BasicDigestAuthHandler(
             domain = null,
@@ -202,7 +278,11 @@ class Dav4jvmCalDavDiscoveryService @Inject constructor(
         const val DAV_NAMESPACE = "DAV:"
         const val CALDAV_NAMESPACE = "urn:ietf:params:xml:ns:caldav"
         const val HTTP_CREATED = 201
+        const val HTTP_ACCEPTED = 202
+        const val HTTP_NO_CONTENT = 204
         const val HTTP_MULTI_STATUS = 207
+        const val HTTP_OK = 200
+        const val HTTP_NOT_FOUND = 404
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403
         const val HTTP_METHOD_NOT_ALLOWED = 405
@@ -218,6 +298,13 @@ private fun String.normalizeBaseUrl(): HttpUrl =
 private fun String.resolveCollectionUrl(collectionHref: String): HttpUrl =
     normalizeBaseUrl().resolve(collectionHref)
         ?: error("Invalid collection URL")
+
+private fun String.resolveItemUrl(itemHref: String): HttpUrl =
+    runCatching { itemHref.toHttpUrl() }
+        .getOrElse {
+            normalizeBaseUrl().resolve(itemHref)
+                ?: error("Invalid item URL")
+        }
 
 private fun String.toListPath(): String {
     val sanitizedName = trim().trim('/').ifBlank { error("List name is required") }
@@ -239,6 +326,8 @@ private fun String.createCollectionRequestBody(): okhttp3.RequestBody {
         )
         .toRequestBody(CALDAV_XML_MEDIA_TYPE)
 }
+
+private fun Request.Builder.delete(): Request.Builder = method("DELETE", null as RequestBody?)
 
 private fun calendarQueryRequestBody() =
     (
@@ -269,4 +358,10 @@ private fun String.escapeXml(): String = buildString(this.length) {
     }
 }
 
+private fun String.parseHttpDate(): Long? =
+    runCatching {
+        ZonedDateTime.parse(this, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant().toEpochMilli()
+    }.getOrNull()
+
 private val CALDAV_XML_MEDIA_TYPE = "application/xml; charset=utf-8".toMediaType()
+private val TEXT_CALENDAR_MEDIA_TYPE = "text/calendar; charset=utf-8".toMediaType()

--- a/app/src/main/java/com/jhow/shopplist/data/sync/NoOpCalDavDiscoveryService.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/sync/NoOpCalDavDiscoveryService.kt
@@ -1,6 +1,7 @@
 package com.jhow.shopplist.data.sync
 
 import com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot
+import com.jhow.shopplist.domain.model.ShoppingItem
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -25,4 +26,25 @@ class NoOpCalDavDiscoveryService @Inject constructor() : CalDavDiscoveryService 
         password: String,
         collectionHref: String
     ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+    override suspend fun upsertTaskItem(
+        serverUrl: String,
+        username: String,
+        password: String,
+        collectionHref: String,
+        item: ShoppingItem
+    ): CalDavTaskUpsertResult = CalDavTaskUpsertResult(
+        remoteUid = item.remoteMetadata.remoteUid ?: item.id,
+        href = item.remoteMetadata.remoteHref ?: "$collectionHref${item.id}.ics",
+        eTag = null,
+        lastModifiedAt = item.updatedAt
+    )
+
+    override suspend fun deleteTaskItem(
+        serverUrl: String,
+        username: String,
+        password: String,
+        href: String,
+        eTag: String?
+    ): CalDavTaskDeleteResult = CalDavTaskDeleteResult(deletedAt = null)
 }

--- a/app/src/main/java/com/jhow/shopplist/data/sync/WorkManagerShoppingSyncScheduler.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/sync/WorkManagerShoppingSyncScheduler.kt
@@ -26,7 +26,7 @@ class WorkManagerShoppingSyncScheduler @Inject constructor(
 
         workManager.enqueueUniqueWork(
             ShoppingSyncWorker.UNIQUE_WORK_NAME,
-            ExistingWorkPolicy.KEEP,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
             request
         )
     }

--- a/app/src/test/java/com/jhow/shopplist/data/sync/CalDavListLocatorTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/data/sync/CalDavListLocatorTest.kt
@@ -77,5 +77,21 @@ class CalDavListLocatorTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: com.jhow.shopplist.domain.model.ShoppingItem
+        ): CalDavTaskUpsertResult = error("Not used in locator tests")
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult = error("Not used in locator tests")
     }
 }

--- a/app/src/test/java/com/jhow/shopplist/data/sync/CalDavShoppingSyncGatewayTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/data/sync/CalDavShoppingSyncGatewayTest.kt
@@ -52,7 +52,7 @@ class CalDavShoppingSyncGatewayTest {
 
         assertTrue(discoveryService.createCollectionCalled)
         assertEquals("Groceries", discoveryService.lastListName)
-        assertEquals("https://dav.example.com/Groceries", configRepository.currentConfig.lastResolvedCollectionUrl)
+        assertEquals("https://dav.example.com/Groceries/", configRepository.currentConfig.lastResolvedCollectionUrl)
         assertFalse(configRepository.currentConfig.createListRequested)
         assertTrue(outcome is CalDavSyncOutcome.Success)
         val success = outcome as CalDavSyncOutcome.Success
@@ -319,7 +319,7 @@ class CalDavShoppingSyncGatewayTest {
             createCollectionCalled = true
             lastListName = listName
             if (throwOnCreate) throw RuntimeException("create failed")
-            return "$serverUrl/$listName"
+            return "$serverUrl/$listName/"
         }
 
         override suspend fun fetchTaskItems(
@@ -328,6 +328,27 @@ class CalDavShoppingSyncGatewayTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: ShoppingItem
+        ): CalDavTaskUpsertResult = CalDavTaskUpsertResult(
+            remoteUid = item.remoteMetadata.remoteUid ?: item.id,
+            href = "$collectionHref${item.id}.ics",
+            eTag = null,
+            lastModifiedAt = item.updatedAt
+        )
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult = CalDavTaskDeleteResult(deletedAt = null)
     }
 
     private fun sampleItem(

--- a/app/src/test/java/com/jhow/shopplist/data/sync/CalDavSyncExecutorTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/data/sync/CalDavSyncExecutorTest.kt
@@ -1,5 +1,6 @@
 package com.jhow.shopplist.data.sync
 
+import com.jhow.shopplist.domain.model.CalDavSyncOutcome
 import com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot
 import com.jhow.shopplist.domain.model.ShoppingItem
 import com.jhow.shopplist.domain.model.ShoppingItemRemoteMetadata
@@ -7,6 +8,8 @@ import com.jhow.shopplist.domain.model.SyncStatus
 import com.jhow.shopplist.testing.FakeShoppingListRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CalDavSyncExecutorTest {
@@ -14,11 +17,12 @@ class CalDavSyncExecutorTest {
     private val planner = CalDavSyncPlanner()
 
     @Test
-    fun `execute does not call markItemsSynced`() = runTest {
+    fun `execute returns sync results for pushed local changes`() = runTest {
+        val discoveryService = FakeDiscoveryService()
         val executor = CalDavSyncExecutor(
             repository = repository,
             planner = planner,
-            discoveryService = FakeDiscoveryService()
+            discoveryService = discoveryService
         )
         repository.seedItems(
             listOf(
@@ -26,14 +30,17 @@ class CalDavSyncExecutorTest {
             )
         )
 
-        executor.execute(
+        val outcome = executor.execute(
             serverUrl = "https://dav.example.com",
             username = "jhow",
             password = "secret",
             collectionHref = "/lists/groceries/"
-        )
+        ) as CalDavSyncOutcome.Success
 
-        assertEquals(0, repository.syncedResults.size)
+        assertEquals(listOf("milk"), discoveryService.upsertedItems.map { it.id })
+        assertEquals(1, outcome.syncedResults.size)
+        assertEquals("uid-milk", outcome.syncedResults.single().remoteUid)
+        assertEquals("/lists/groceries/milk.ics", outcome.syncedResults.single().remoteHref)
     }
 
     @Test
@@ -71,12 +78,107 @@ class CalDavSyncExecutorTest {
         assertEquals("uid-apples", repository.importedItems.single().remoteUid)
         assertEquals(1, repository.applyRemoteDeletesCallCount)
         assertEquals(listOf("local-bread"), repository.remoteDeletedRequests)
-        assertEquals(1, (outcome as com.jhow.shopplist.domain.model.CalDavSyncOutcome.Success).importedCount)
+        assertEquals(1, (outcome as CalDavSyncOutcome.Success).importedCount)
+    }
+
+    @Test
+    fun `execute applies remote updates to existing linked items`() = runTest {
+        val executor = CalDavSyncExecutor(
+            repository = repository,
+            planner = planner,
+            discoveryService = FakeDiscoveryService(
+                remoteItems = listOf(
+                    RemoteShoppingItemSnapshot(
+                        remoteUid = "uid-milk",
+                        summary = "Oat Milk",
+                        isCompleted = true,
+                        href = "/lists/groceries/uid-milk.ics",
+                        eTag = "etag-milk-2",
+                        lastModifiedAt = 5_000L
+                    )
+                )
+            )
+        )
+        repository.seedItems(
+            listOf(
+                sampleItem(
+                    id = "local-milk",
+                    name = "Milk",
+                    syncStatus = SyncStatus.SYNCED,
+                    remoteUid = "uid-milk",
+                    remoteHref = "/lists/groceries/uid-milk.ics",
+                    remoteEtag = "etag-milk-1",
+                    remoteLastModifiedAt = 1_000L
+                )
+            )
+        )
+
+        executor.execute(
+            serverUrl = "https://dav.example.com",
+            username = "jhow",
+            password = "secret",
+            collectionHref = "/lists/groceries/"
+        )
+
+        val updatedItem = repository.getAllItems().single()
+        assertEquals("Oat Milk", updatedItem.name)
+        assertTrue(updatedItem.isPurchased)
+        assertEquals(1, updatedItem.purchaseCount)
+        assertEquals("etag-milk-2", updatedItem.remoteMetadata.remoteEtag)
+        assertEquals(5_000L, updatedItem.remoteMetadata.remoteLastModifiedAt)
+    }
+
+    @Test
+    fun `execute deletes remote item for pending local delete`() = runTest {
+        val discoveryService = FakeDiscoveryService(
+            remoteItems = listOf(
+                RemoteShoppingItemSnapshot(
+                    remoteUid = "uid-milk",
+                    summary = "Milk",
+                    isCompleted = false,
+                    href = "/lists/groceries/uid-milk.ics",
+                    eTag = "etag-milk",
+                    lastModifiedAt = 5_000L
+                )
+            )
+        )
+        val executor = CalDavSyncExecutor(
+            repository = repository,
+            planner = planner,
+            discoveryService = discoveryService
+        )
+        repository.seedItems(
+            listOf(
+                sampleItem(
+                    id = "local-milk",
+                    syncStatus = SyncStatus.PENDING_DELETE,
+                    remoteUid = "uid-milk",
+                    remoteHref = "/lists/groceries/uid-milk.ics",
+                    remoteEtag = "etag-milk"
+                ).copy(isDeleted = true)
+            )
+        )
+
+        val outcome = executor.execute(
+            serverUrl = "https://dav.example.com",
+            username = "jhow",
+            password = "secret",
+            collectionHref = "/lists/groceries/"
+        ) as CalDavSyncOutcome.Success
+
+        assertEquals(listOf("/lists/groceries/uid-milk.ics"), discoveryService.deletedHrefs)
+        val deleteResult = outcome.syncedResults.single()
+        assertEquals("local-milk", deleteResult.id)
+        assertTrue(deleteResult.deletedRemotely)
+        assertNull(deleteResult.remoteEtag)
     }
 
     private class FakeDiscoveryService(
         private val remoteItems: List<RemoteShoppingItemSnapshot> = emptyList()
     ) : CalDavDiscoveryService {
+        val upsertedItems = mutableListOf<ShoppingItem>()
+        val deletedHrefs = mutableListOf<String>()
+
         override suspend fun findTaskCollections(
             serverUrl: String,
             username: String,
@@ -96,21 +198,58 @@ class CalDavSyncExecutorTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = remoteItems
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: ShoppingItem
+        ): CalDavTaskUpsertResult {
+            upsertedItems += item
+            return CalDavTaskUpsertResult(
+                remoteUid = item.remoteMetadata.remoteUid ?: "uid-${item.id}",
+                href = "$collectionHref${item.id}.ics",
+                eTag = "etag-${item.id}",
+                lastModifiedAt = 9_000L
+            )
+        }
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult {
+            deletedHrefs += href
+            return CalDavTaskDeleteResult(deletedAt = 9_000L)
+        }
     }
 
     private fun sampleItem(
         id: String,
         syncStatus: SyncStatus,
-        remoteUid: String? = null
+        name: String = id,
+        remoteUid: String? = null,
+        remoteHref: String? = null,
+        remoteEtag: String? = null,
+        remoteLastModifiedAt: Long? = null
     ): ShoppingItem = ShoppingItem(
         id = id,
-        name = id,
+        name = name,
         isPurchased = false,
         purchaseCount = 0,
         createdAt = 1L,
         updatedAt = 2L,
         isDeleted = false,
         syncStatus = syncStatus,
-        remoteMetadata = ShoppingItemRemoteMetadata(remoteUid = remoteUid)
+        remoteMetadata = ShoppingItemRemoteMetadata(
+            remoteUid = remoteUid,
+            remoteHref = remoteHref,
+            remoteEtag = remoteEtag,
+            remoteLastModifiedAt = remoteLastModifiedAt,
+            lastSyncedAt = remoteLastModifiedAt
+        )
     )
 }

--- a/app/src/test/java/com/jhow/shopplist/data/sync/CalDavSyncPlannerTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/data/sync/CalDavSyncPlannerTest.kt
@@ -24,7 +24,10 @@ class CalDavSyncPlannerTest {
         val plan = planner.plan(localItems = localItems, remoteItems = remoteItems)
 
         assertEquals(listOf("milk"), plan.itemsToPush.map { it.id })
+        assertEquals(emptyList<String>(), plan.itemsToDeleteRemotely.map { it.id })
         assertEquals(listOf("Apples"), plan.itemsToImport.map { it.summary })
+        assertEquals(emptyList<String>(), plan.itemsToUpdateLocally.map { it.summary })
+        assertEquals(emptyList<String>(), plan.itemsToMarkSynced.map { it.id })
         assertEquals(setOf("uid-bread"), plan.remoteUidsToDeleteLocally)
     }
 
@@ -34,16 +37,18 @@ class CalDavSyncPlannerTest {
         val localItems = listOf(
             sampleLocal(id = "new-item", remoteUid = null, syncStatus = SyncStatus.PENDING_INSERT)
         )
-        val remoteItems = emptyList<RemoteShoppingItemSnapshot>()
 
-        val plan = planner.plan(localItems = localItems, remoteItems = remoteItems)
+        val plan = planner.plan(localItems = localItems, remoteItems = emptyList())
 
         assertEquals(listOf("new-item"), plan.itemsToPush.map { it.id })
+        assertEquals(emptyList<String>(), plan.itemsToDeleteRemotely.map { it.id })
+        assertEquals(emptyList<String>(), plan.itemsToUpdateLocally.map { it.summary })
+        assertEquals(emptyList<String>(), plan.itemsToMarkSynced.map { it.id })
         assertEquals(emptySet<String>(), plan.remoteUidsToDeleteLocally)
     }
 
     @Test
-    fun `PENDING_DELETE item whose UID still exists remotely goes to itemsToPush and is not deleted locally`() {
+    fun `PENDING_DELETE item whose UID still exists remotely is deleted remotely and not deleted locally`() {
         val planner = CalDavSyncPlanner()
         val localItems = listOf(
             sampleLocal(id = "stale-item", remoteUid = "uid-stale", syncStatus = SyncStatus.PENDING_DELETE)
@@ -54,7 +59,24 @@ class CalDavSyncPlannerTest {
 
         val plan = planner.plan(localItems = localItems, remoteItems = remoteItems)
 
-        assertEquals(listOf("stale-item"), plan.itemsToPush.map { it.id })
+        assertEquals(emptyList<String>(), plan.itemsToPush.map { it.id })
+        assertEquals(listOf("stale-item"), plan.itemsToDeleteRemotely.map { it.id })
+        assertEquals(emptyList<String>(), plan.itemsToMarkSynced.map { it.id })
+        assertEquals(emptySet<String>(), plan.remoteUidsToDeleteLocally)
+    }
+
+    @Test
+    fun `PENDING_DELETE item whose UID is already absent remotely is marked synced locally`() {
+        val planner = CalDavSyncPlanner()
+        val localItems = listOf(
+            sampleLocal(id = "stale-item", remoteUid = "uid-stale", syncStatus = SyncStatus.PENDING_DELETE)
+        )
+
+        val plan = planner.plan(localItems = localItems, remoteItems = emptyList())
+
+        assertEquals(emptyList<String>(), plan.itemsToPush.map { it.id })
+        assertEquals(emptyList<String>(), plan.itemsToDeleteRemotely.map { it.id })
+        assertEquals(listOf("stale-item"), plan.itemsToMarkSynced.map { it.id })
         assertEquals(emptySet<String>(), plan.remoteUidsToDeleteLocally)
     }
 
@@ -65,23 +87,28 @@ class CalDavSyncPlannerTest {
         val plan = planner.plan(localItems = emptyList(), remoteItems = emptyList())
 
         assertEquals(emptyList<ShoppingItem>(), plan.itemsToPush)
+        assertEquals(emptyList<ShoppingItem>(), plan.itemsToDeleteRemotely)
         assertEquals(emptyList<RemoteShoppingItemSnapshot>(), plan.itemsToImport)
+        assertEquals(emptyList<RemoteShoppingItemSnapshot>(), plan.itemsToUpdateLocally)
+        assertEquals(emptyList<ShoppingItem>(), plan.itemsToMarkSynced)
         assertEquals(emptySet<String>(), plan.remoteUidsToDeleteLocally)
     }
 
     @Test
     fun `all-remote-no-local imports every remote item`() {
         val planner = CalDavSyncPlanner()
-        val localItems = emptyList<ShoppingItem>()
         val remoteItems = listOf(
             sampleRemote(remoteUid = "uid-1", summary = "One", isCompleted = false),
             sampleRemote(remoteUid = "uid-2", summary = "Two", isCompleted = true)
         )
 
-        val plan = planner.plan(localItems = localItems, remoteItems = remoteItems)
+        val plan = planner.plan(localItems = emptyList(), remoteItems = remoteItems)
 
         assertEquals(emptyList<String>(), plan.itemsToPush)
+        assertEquals(emptyList<String>(), plan.itemsToDeleteRemotely.map { it.id })
         assertEquals(listOf("One", "Two"), plan.itemsToImport.map { it.summary })
+        assertEquals(emptyList<String>(), plan.itemsToUpdateLocally.map { it.summary })
+        assertEquals(emptyList<String>(), plan.itemsToMarkSynced.map { it.id })
         assertEquals(emptySet<String>(), plan.remoteUidsToDeleteLocally)
     }
 
@@ -92,42 +119,100 @@ class CalDavSyncPlannerTest {
             sampleLocal(id = "milk", remoteUid = "uid-milk", syncStatus = SyncStatus.SYNCED),
             sampleLocal(id = "bread", remoteUid = "uid-bread", syncStatus = SyncStatus.SYNCED)
         )
-        val remoteItems = emptyList<RemoteShoppingItemSnapshot>()
+
+        val plan = planner.plan(localItems = localItems, remoteItems = emptyList())
+
+        assertEquals(emptyList<ShoppingItem>(), plan.itemsToPush)
+        assertEquals(emptyList<ShoppingItem>(), plan.itemsToDeleteRemotely)
+        assertEquals(emptyList<RemoteShoppingItemSnapshot>(), plan.itemsToImport)
+        assertEquals(emptyList<RemoteShoppingItemSnapshot>(), plan.itemsToUpdateLocally)
+        assertEquals(emptyList<ShoppingItem>(), plan.itemsToMarkSynced)
+        assertEquals(setOf("uid-milk", "uid-bread"), plan.remoteUidsToDeleteLocally)
+    }
+
+    @Test
+    fun `remote update for synced linked item goes to itemsToUpdateLocally`() {
+        val planner = CalDavSyncPlanner()
+        val localItems = listOf(
+            sampleLocal(
+                id = "milk",
+                remoteUid = "uid-milk",
+                syncStatus = SyncStatus.SYNCED,
+                name = "Milk",
+                remoteLastModifiedAt = 100L
+            )
+        )
+        val remoteItems = listOf(
+            sampleRemote(remoteUid = "uid-milk", summary = "Oat Milk", isCompleted = true, lastModifiedAt = 200L)
+        )
 
         val plan = planner.plan(localItems = localItems, remoteItems = remoteItems)
 
-        assertEquals(emptyList<ShoppingItem>(), plan.itemsToPush)
-        assertEquals(emptyList<RemoteShoppingItemSnapshot>(), plan.itemsToImport)
-        assertEquals(setOf("uid-milk", "uid-bread"), plan.remoteUidsToDeleteLocally)
+        assertEquals(listOf("Oat Milk"), plan.itemsToUpdateLocally.map { it.summary })
+        assertEquals(emptyList<String>(), plan.itemsToPush.map { it.id })
+    }
+
+    @Test
+    fun `newer remote update wins over pending local update`() {
+        val planner = CalDavSyncPlanner()
+        val localItems = listOf(
+            sampleLocal(
+                id = "milk",
+                remoteUid = "uid-milk",
+                syncStatus = SyncStatus.PENDING_UPDATE,
+                name = "Local Milk",
+                updatedAt = 150L,
+                remoteLastModifiedAt = 100L,
+                lastSyncedAt = 100L
+            )
+        )
+        val remoteItems = listOf(
+            sampleRemote(remoteUid = "uid-milk", summary = "Remote Milk", isCompleted = true, lastModifiedAt = 250L)
+        )
+
+        val plan = planner.plan(localItems = localItems, remoteItems = remoteItems)
+
+        assertEquals(emptyList<String>(), plan.itemsToPush.map { it.id })
+        assertEquals(listOf("Remote Milk"), plan.itemsToUpdateLocally.map { it.summary })
     }
 
     private fun sampleLocal(
         id: String,
         remoteUid: String? = null,
         syncStatus: SyncStatus,
-        name: String = id
+        name: String = id,
+        updatedAt: Long = 2L,
+        remoteLastModifiedAt: Long? = null,
+        lastSyncedAt: Long? = null
     ): ShoppingItem = ShoppingItem(
         id = id,
         name = name,
         isPurchased = false,
         purchaseCount = 0,
         createdAt = 1L,
-        updatedAt = 2L,
+        updatedAt = updatedAt,
         isDeleted = false,
         syncStatus = syncStatus,
-        remoteMetadata = ShoppingItemRemoteMetadata(remoteUid = remoteUid)
+        remoteMetadata = ShoppingItemRemoteMetadata(
+            remoteUid = remoteUid,
+            remoteHref = remoteUid?.let { "/lists/groceries/$it.ics" },
+            remoteEtag = remoteUid?.let { "etag-$it" },
+            remoteLastModifiedAt = remoteLastModifiedAt,
+            lastSyncedAt = lastSyncedAt
+        )
     )
 
     private fun sampleRemote(
         remoteUid: String,
         summary: String,
-        isCompleted: Boolean
+        isCompleted: Boolean,
+        lastModifiedAt: Long = 100L
     ): RemoteShoppingItemSnapshot = RemoteShoppingItemSnapshot(
         remoteUid = remoteUid,
         summary = summary,
         isCompleted = isCompleted,
         href = "/lists/groceries/$remoteUid.ics",
         eTag = "etag-$remoteUid",
-        lastModifiedAt = 100L
+        lastModifiedAt = lastModifiedAt
     )
 }

--- a/app/src/test/java/com/jhow/shopplist/domain/usecase/ConfirmCreateCalDavListUseCaseTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/usecase/ConfirmCreateCalDavListUseCaseTest.kt
@@ -3,6 +3,8 @@ package com.jhow.shopplist.domain.usecase
 import com.jhow.shopplist.data.sync.CalDavCollectionCandidate
 import com.jhow.shopplist.data.sync.CalDavAuthenticationException
 import com.jhow.shopplist.data.sync.CalDavDiscoveryService
+import com.jhow.shopplist.data.sync.CalDavTaskDeleteResult
+import com.jhow.shopplist.data.sync.CalDavTaskUpsertResult
 import com.jhow.shopplist.domain.model.CalDavValidationResult
 import com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot
 import com.jhow.shopplist.testing.FakeCalDavConfigRepository
@@ -207,6 +209,22 @@ class ConfirmCreateCalDavListUseCaseTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: com.jhow.shopplist.domain.model.ShoppingItem
+        ): CalDavTaskUpsertResult = error("Not used in create-list tests")
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult = error("Not used in create-list tests")
     }
 
     private class ContextRecordingDiscoveryService(
@@ -237,6 +255,22 @@ class ConfirmCreateCalDavListUseCaseTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: com.jhow.shopplist.domain.model.ShoppingItem
+        ): CalDavTaskUpsertResult = error("Not used in create-list tests")
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult = error("Not used in create-list tests")
     }
 
     private fun newNamedDispatcher(threadName: String): ExecutorCoroutineDispatcher {

--- a/app/src/test/java/com/jhow/shopplist/domain/usecase/SyncPendingShoppingItemsUseCaseTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/usecase/SyncPendingShoppingItemsUseCaseTest.kt
@@ -103,7 +103,7 @@ class SyncPendingShoppingItemsUseCaseTest {
     }
 
     @Test
-    fun `importRemoteItems skips already known remote uids`() = runTest {
+    fun `importRemoteItems merges known remote uids and imports new ones`() = runTest {
         repository.seedItems(
             listOf(
                 sampleItem(id = "local-milk", syncStatus = SyncStatus.SYNCED, remoteUid = "uid-milk")
@@ -135,7 +135,9 @@ class SyncPendingShoppingItemsUseCaseTest {
         assertEquals(2, allItems.size)
         val milk = allItems.single { it.remoteMetadata.remoteUid == "uid-milk" }
         assertEquals("local-milk", milk.id)
-        assertEquals("local-milk", milk.name)
+        assertEquals("Milk Updated", milk.name)
+        assertEquals(true, milk.isPurchased)
+        assertEquals("etag-milk-2", milk.remoteMetadata.remoteEtag)
     }
 
     @Test

--- a/app/src/test/java/com/jhow/shopplist/domain/usecase/ValidateCalDavSyncSettingsUseCaseTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/usecase/ValidateCalDavSyncSettingsUseCaseTest.kt
@@ -4,6 +4,8 @@ import com.jhow.shopplist.data.sync.CalDavCollectionCandidate
 import com.jhow.shopplist.data.sync.CalDavAuthenticationException
 import com.jhow.shopplist.data.sync.CalDavDiscoveryService
 import com.jhow.shopplist.data.sync.CalDavListLocator
+import com.jhow.shopplist.data.sync.CalDavTaskDeleteResult
+import com.jhow.shopplist.data.sync.CalDavTaskUpsertResult
 import com.jhow.shopplist.domain.model.CalDavValidationResult
 import com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot
 import com.jhow.shopplist.testing.FakeCalDavConfigRepository
@@ -342,6 +344,22 @@ class ValidateCalDavSyncSettingsUseCaseTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: com.jhow.shopplist.domain.model.ShoppingItem
+        ): CalDavTaskUpsertResult = error("Not used in validation tests")
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult = error("Not used in validation tests")
     }
 
     private class ContextRecordingDiscoveryService(
@@ -372,6 +390,22 @@ class ValidateCalDavSyncSettingsUseCaseTest {
             password: String,
             collectionHref: String
         ): List<RemoteShoppingItemSnapshot> = emptyList()
+
+        override suspend fun upsertTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            collectionHref: String,
+            item: com.jhow.shopplist.domain.model.ShoppingItem
+        ): CalDavTaskUpsertResult = error("Not used in validation tests")
+
+        override suspend fun deleteTaskItem(
+            serverUrl: String,
+            username: String,
+            password: String,
+            href: String,
+            eTag: String?
+        ): CalDavTaskDeleteResult = error("Not used in validation tests")
     }
 
     private fun newNamedDispatcher(threadName: String): ExecutorCoroutineDispatcher {

--- a/app/src/test/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigViewModelTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigViewModelTest.kt
@@ -220,6 +220,22 @@ class CalDavConfigViewModelTest {
                     password: String,
                     collectionHref: String
                 ) = emptyList<com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot>()
+
+                override suspend fun upsertTaskItem(
+                    serverUrl: String,
+                    username: String,
+                    password: String,
+                    collectionHref: String,
+                    item: com.jhow.shopplist.domain.model.ShoppingItem
+                ) = error("Not used")
+
+                override suspend fun deleteTaskItem(
+                    serverUrl: String,
+                    username: String,
+                    password: String,
+                    href: String,
+                    eTag: String?
+                ) = error("Not used")
             }
         ),
         ioDispatcher = UnconfinedTestDispatcher()
@@ -259,6 +275,22 @@ class CalDavConfigViewModelTest {
                 password: String,
                 collectionHref: String
             ) = emptyList<com.jhow.shopplist.domain.model.RemoteShoppingItemSnapshot>()
+
+            override suspend fun upsertTaskItem(
+                serverUrl: String,
+                username: String,
+                password: String,
+                collectionHref: String,
+                item: com.jhow.shopplist.domain.model.ShoppingItem
+            ) = error("Not used")
+
+            override suspend fun deleteTaskItem(
+                serverUrl: String,
+                username: String,
+                password: String,
+                href: String,
+                eTag: String?
+            ) = error("Not used")
         },
         ioDispatcher = UnconfinedTestDispatcher()
     ) {

--- a/app/src/test/java/com/jhow/shopplist/testing/FakeShoppingListRepository.kt
+++ b/app/src/test/java/com/jhow/shopplist/testing/FakeShoppingListRepository.kt
@@ -121,30 +121,57 @@ class FakeShoppingListRepository : ShoppingListRepository {
     override suspend fun getAllItems(): List<ShoppingItem> = items.value
 
     override suspend fun importRemoteItems(items: List<RemoteShoppingItemSnapshot>) {
-        val knownRemoteUids = this.items.value
-            .mapNotNull { it.remoteMetadata.remoteUid }
-            .toSet()
-        val newItems = items.filter { it.remoteUid !in knownRemoteUids }
+        val existingByRemoteUid = this.items.value
+            .mapNotNull { item ->
+                item.remoteMetadata.remoteUid?.let { remoteUid -> remoteUid to item }
+            }
+            .toMap()
+        val newItems = items.filter { it.remoteUid !in existingByRemoteUid }
         importedItems += newItems
         val now = 5_000L + this.items.value.size
-        this.items.value = this.items.value + newItems.map { remote ->
-            ShoppingItem(
-                id = "imported-${remote.remoteUid}",
-                name = remote.summary,
-                isPurchased = remote.isCompleted,
-                purchaseCount = if (remote.isCompleted) 1 else 0,
-                createdAt = remote.lastModifiedAt ?: now,
-                updatedAt = remote.lastModifiedAt ?: now,
-                isDeleted = false,
-                syncStatus = SyncStatus.SYNCED,
-                remoteMetadata = ShoppingItemRemoteMetadata(
-                    remoteUid = remote.remoteUid,
-                    remoteHref = remote.href,
-                    remoteEtag = remote.eTag,
-                    remoteLastModifiedAt = remote.lastModifiedAt,
-                    lastSyncedAt = now
+        val retainedItems = this.items.value.filter { item ->
+            item.remoteMetadata.remoteUid !in items.mapTo(mutableSetOf()) { remote -> remote.remoteUid }
+        }
+        this.items.value = retainedItems + items.map { remote ->
+            val existing = existingByRemoteUid[remote.remoteUid]
+            if (existing == null) {
+                ShoppingItem(
+                    id = "imported-${remote.remoteUid}",
+                    name = remote.summary,
+                    isPurchased = remote.isCompleted,
+                    purchaseCount = if (remote.isCompleted) 1 else 0,
+                    createdAt = remote.lastModifiedAt ?: now,
+                    updatedAt = remote.lastModifiedAt ?: now,
+                    isDeleted = false,
+                    syncStatus = SyncStatus.SYNCED,
+                    remoteMetadata = ShoppingItemRemoteMetadata(
+                        remoteUid = remote.remoteUid,
+                        remoteHref = remote.href,
+                        remoteEtag = remote.eTag,
+                        remoteLastModifiedAt = remote.lastModifiedAt,
+                        lastSyncedAt = now
+                    )
                 )
-            )
+            } else {
+                existing.copy(
+                    name = remote.summary,
+                    isPurchased = remote.isCompleted,
+                    purchaseCount = when {
+                        remote.isCompleted && !existing.isPurchased -> existing.purchaseCount + 1
+                        else -> existing.purchaseCount
+                    },
+                    updatedAt = remote.lastModifiedAt ?: now,
+                    isDeleted = false,
+                    syncStatus = SyncStatus.SYNCED,
+                    remoteMetadata = ShoppingItemRemoteMetadata(
+                        remoteUid = remote.remoteUid,
+                        remoteHref = remote.href,
+                        remoteEtag = remote.eTag,
+                        remoteLastModifiedAt = remote.lastModifiedAt,
+                        lastSyncedAt = now
+                    )
+                )
+            }
         }
     }
 
@@ -171,7 +198,14 @@ class FakeShoppingListRepository : ShoppingListRepository {
             val result = resultMap[item.id] ?: return@map item
             item.copy(
                 updatedAt = result.serverUpdatedAt,
-                syncStatus = SyncStatus.SYNCED
+                syncStatus = SyncStatus.SYNCED,
+                remoteMetadata = item.remoteMetadata.copy(
+                    remoteUid = result.remoteUid ?: item.remoteMetadata.remoteUid,
+                    remoteHref = result.remoteHref ?: item.remoteMetadata.remoteHref,
+                    remoteEtag = result.remoteEtag,
+                    remoteLastModifiedAt = result.remoteLastModifiedAt,
+                    lastSyncedAt = result.lastSyncedAt
+                )
             )
         }
     }

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Fixes the CalDAV sync flow so that local changes are actually pushed to the server, upstream changes are merged into local linked items, and repeated sync requests are reliably scheduled.

## Root causes fixed

1. **No remote write path**: `CalDavSyncExecutor` only fabricated `ShoppingItemSyncResult` without calling the server.
2. **No remote merge for linked items**: `importRemoteItems()` skipped any remote UID that was already known locally.
3. **No real planner reconcile**: the planner had no paths for remote updates, pending deletes, or timestamp-based conflict resolution.
4. **Sync requests dropped**: `WorkManagerShoppingSyncScheduler` used `ExistingWorkPolicy.KEEP`, which silently ignored new requests while one was already queued.

## Changes

- Add `upsertTaskItem()` and `deleteTaskItem()` to `CalDavDiscoveryService`
- Implement real `PUT`/`DELETE` in `Dav4jvmCalDavDiscoveryService`
- Update `CalDavSyncPlanner` to handle:
  - local push
  - remote update merge for linked items
  - remote deletes
  - pending-delete reconciliation
  - conservative timestamp-based conflict rules
- Update `ShoppingListRepositoryImpl.importRemoteItems()` to merge existing rows instead of skipping them
- Change WorkManager policy to `APPEND_OR_REPLACE`
- Update all affected test doubles
- Add regression tests for local push, upstream import, upstream update merge, and delete flow
- Fix instrumented test to match actual Material pull-to-refresh UX

## Verification

- `./gradlew testDebugUnitTest` passed
- `./gradlew connectedDebugAndroidTest` passed
- `./gradlew lintDebug` passed