### PR TITLE
feat(sync): decouple manual sync visual from background sync

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# JhowShoppList — Domain Context
+
+## Glossary
+
+### Manual sync
+A sync gesture explicitly initiated by the user — currently, tapping the sync badge in the top app bar. Manual syncs surface a prominent, centered progress indicator on the shopping list screen for the duration of the in-flight sync (and any sync work that overlaps with it).
+
+### Background sync
+A sync triggered as a side effect of a local mutation (add, purchase, unpurchase, delete) or by a scheduler/lifecycle event (app resume, network reconnect, periodic tick). Background syncs surface only a small spinner in the top app bar; they never take over the screen.
+
+The distinction between manual and background syncs is a presentation concern. The sync engine itself does not behave differently based on who asked.
+
+### Offline-first
+The shopping list is the source of truth on the device. All mutations apply locally and immediately, regardless of network or sync state. Sync reconciles with the remote CalDAV list in the background; UI never blocks on sync, and a failed/missing sync never prevents the user from using the list.
+
+### Sync configured
+The user has supplied valid CalDAV credentials and selected (or created) a target list. Until sync is configured, the sync badge is hidden — the settings cog is the only path to configuration.

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListPullRefreshTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListPullRefreshTest.kt
@@ -52,14 +52,14 @@ class ShoppingListPullRefreshTest {
     }
 
     @Test
-    fun pullDownGesture_invokesOnPullToRefresh() {
-        var pullToRefreshInvoked = false
+    fun pullDownGesture_invokesOnManualSyncRequested() {
+        var manualSyncInvoked = false
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(),
                 snackbarHostState = SnackbarHostState(),
                 syncCallbacks = ShoppingListSyncCallbacks(
-                    onPullToRefresh = { pullToRefreshInvoked = true }
+                    onManualSyncRequested = { manualSyncInvoked = true }
                 )
             )
         }
@@ -69,14 +69,14 @@ class ShoppingListPullRefreshTest {
             .performTouchInput { swipeDown() }
         composeRule.waitForIdle()
 
-        assertTrue("Pull-to-refresh callback should fire", pullToRefreshInvoked)
+        assertTrue("Pull-to-refresh callback should fire", manualSyncInvoked)
     }
 
     @Test
-    fun pullToRefreshSpinner_visible_whenIsSyncingTrue() {
+    fun pullToRefreshSpinner_visible_whenIsManualSyncTrue() {
         composeRule.setContent {
             ShoppingListScreen(
-                uiState = ShoppingListUiState(isSyncing = true),
+                uiState = ShoppingListUiState(isManualSync = true),
                 snackbarHostState = SnackbarHostState()
             )
         }
@@ -86,10 +86,10 @@ class ShoppingListPullRefreshTest {
     }
 
     @Test
-    fun pullToRefreshSpinner_remainsAvailable_whenIsSyncingFalse() {
+    fun pullToRefreshSpinner_remainsAvailable_whenIsManualSyncFalse() {
         composeRule.setContent {
             ShoppingListScreen(
-                uiState = ShoppingListUiState(isSyncing = false),
+                uiState = ShoppingListUiState(isManualSync = false),
                 snackbarHostState = SnackbarHostState()
             )
         }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -107,7 +107,7 @@ class ShoppingListItemCallbacks(
 )
 
 class ShoppingListSyncCallbacks(
-    val onPullToRefresh: () -> Unit = {},
+    val onManualSyncRequested: () -> Unit = {},
     val onSyncSettingsClicked: () -> Unit = {}
 )
 
@@ -213,7 +213,7 @@ fun ShoppingListRoute(
     }
     val syncCallbacks = remember(viewModel) {
         ShoppingListSyncCallbacks(
-            onPullToRefresh = viewModel::onPullToRefresh,
+            onManualSyncRequested = viewModel::onManualSyncRequested,
             onSyncSettingsClicked = onNavigateToCalDavConfig
         )
     }
@@ -290,8 +290,8 @@ private fun ShoppingListScreenContent(
     ) {
         val pullState = rememberPullToRefreshState()
         PullToRefreshBox(
-            isRefreshing = uiState.isSyncing,
-            onRefresh = syncCallbacks.onPullToRefresh,
+            isRefreshing = uiState.isManualSync,
+            onRefresh = syncCallbacks.onManualSyncRequested,
             state = pullState,
             modifier = Modifier
                 .fillMaxSize()
@@ -299,7 +299,7 @@ private fun ShoppingListScreenContent(
             indicator = {
                 PullToRefreshDefaults.Indicator(
                     state = pullState,
-                    isRefreshing = uiState.isSyncing,
+                    isRefreshing = uiState.isManualSync,
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .testTag(ShoppingListTestTags.PULL_REFRESH_SPINNER)

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiState.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiState.kt
@@ -11,7 +11,8 @@ data class ShoppingListUiState(
     val purchasedItems: List<ShoppingItem> = emptyList(),
     val selectedIds: Set<String> = emptySet(),
     val itemPendingDeletion: ShoppingItem? = null,
-    val isSyncing: Boolean = false,
+    val isManualSync: Boolean = false,
+    val isBackgroundSync: Boolean = false,
     val isSyncConfigured: Boolean = false
 ) {
     val isBulkActionVisible: Boolean

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
@@ -25,7 +25,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -84,14 +88,38 @@ class ShoppingListViewModel @Inject constructor(
         )
     }
 
-    private val isSyncing = observeSyncStateUseCase()
+    private val isSyncing = observeSyncStateUseCase().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+    )
     private val isSyncConfigured = getCalDavSyncConfigUseCase()
         .map { it.isReadyToSync }
         .distinctUntilChanged()
+    private val manualSyncLatch = MutableStateFlow(false)
+    private val hasPendingSyncRequest = MutableStateFlow(false)
+
+    init {
+        isSyncing
+            .scan(false to false) { prev, current -> prev.second to current }
+            .onEach { (prev, current) ->
+                if (current) {
+                    hasPendingSyncRequest.value = false
+                }
+                if (prev && !current) {
+                    manualSyncLatch.value = false
+                    hasPendingSyncRequest.value = false
+                }
+            }
+            .launchIn(viewModelScope)
+    }
 
     val uiState: StateFlow<ShoppingListUiState> = combinedState
         .combine(isSyncing) { intermediate, syncing -> intermediate to syncing }
-        .combine(isSyncConfigured) { (intermediate, syncing), configured ->
+        .combine(manualSyncLatch) { (intermediate, syncing), latch ->
+            Triple(intermediate, syncing, latch)
+        }
+        .combine(isSyncConfigured) { (intermediate, syncing, latch), configured ->
             val pendingIds = intermediate.pendingItems.mapTo(linkedSetOf()) { it.id }
             val distinctPurchasedItems = intermediate.purchasedItems.filterNot { it.id in pendingIds }
             val visibleItems = intermediate.pendingItems + distinctPurchasedItems
@@ -103,7 +131,8 @@ class ShoppingListViewModel @Inject constructor(
                 purchasedItems = distinctPurchasedItems,
                 selectedIds = intermediate.selectedIds.intersect(pendingIds),
                 itemPendingDeletion = visibleItems.firstOrNull { it.id == intermediate.itemPendingDeletion?.id },
-                isSyncing = syncing,
+                isManualSync = syncing && latch,
+                isBackgroundSync = syncing && !latch,
                 isSyncConfigured = configured
             )
         }.stateIn(
@@ -128,7 +157,7 @@ class ShoppingListViewModel @Inject constructor(
         viewModelScope.launch {
             addOrReclaimShoppingItemUseCase(currentValue)
             inputValue.value = ""
-            requestShoppingSyncUseCase()
+            requestSync()
         }
     }
 
@@ -145,7 +174,7 @@ class ShoppingListViewModel @Inject constructor(
         viewModelScope.launch {
             markSelectedItemsPurchasedUseCase(ids)
             selectedIds.value = emptySet()
-            requestShoppingSyncUseCase()
+            requestSync()
         }
     }
 
@@ -153,7 +182,7 @@ class ShoppingListViewModel @Inject constructor(
         viewModelScope.launch {
             markPurchasedItemPendingUseCase(id)
             selectedIds.update { it - id }
-            requestShoppingSyncUseCase()
+            requestSync()
         }
     }
 
@@ -172,18 +201,26 @@ class ShoppingListViewModel @Inject constructor(
             deleteShoppingItemUseCase(item.id)
             selectedIds.update { it - item.id }
             itemPendingDeletion.value = null
-            requestShoppingSyncUseCase()
+            requestSync()
         }
     }
 
-    fun onPullToRefresh() {
+    fun onManualSyncRequested() {
         if (!uiState.value.isSyncConfigured) {
             _uiEvents.tryEmit(ShoppingListUiEvent.SyncNotConfigured)
             return
         }
-        viewModelScope.launch {
-            requestShoppingSyncUseCase()
+        manualSyncLatch.value = true
+        if (!isSyncing.value && !hasPendingSyncRequest.value) {
+            viewModelScope.launch {
+                requestSync()
+            }
         }
+    }
+
+    private fun requestSync() {
+        hasPendingSyncRequest.value = true
+        requestShoppingSyncUseCase()
     }
 
     private companion object {

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
@@ -301,16 +301,132 @@ class ShoppingListViewModelTest {
     }
 
     @Test
-    fun `isSyncing reflects scheduler observe sync state`() = runTest {
+    fun `background sync without manual request exposes isBackgroundSync only`() = runTest {
         syncScheduler.setSyncing(true)
         advanceUntilIdle()
 
-        assertTrue(viewModel.uiState.value.isSyncing)
+        assertFalse(viewModel.uiState.value.isManualSync)
+        assertTrue(viewModel.uiState.value.isBackgroundSync)
 
         syncScheduler.setSyncing(false)
         advanceUntilIdle()
 
-        assertFalse(viewModel.uiState.value.isSyncing)
+        assertFalse(viewModel.uiState.value.isManualSync)
+        assertFalse(viewModel.uiState.value.isBackgroundSync)
+    }
+
+    @Test
+    fun `mutation during manual sync keeps isManualSync true until queue drains`() = runTest {
+        calDavConfigRepository.seed(
+            enabled = true,
+            serverUrl = "https://example.com",
+            username = "user",
+            listName = "Shopping"
+        )
+        advanceUntilIdle()
+
+        syncScheduler.setSyncing(true)
+        viewModel.onManualSyncRequested()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isManualSync)
+
+        // Simulate mutation-triggered background sync overlapping with manual sync
+        viewModel.onInputValueChange("Milk")
+        viewModel.onAddItem()
+        advanceUntilIdle()
+
+        assertEquals(listOf("Milk"), repository.addedNames)
+        assertTrue(viewModel.uiState.value.isManualSync)
+
+        syncScheduler.setSyncing(false)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isManualSync)
+    }
+
+    @Test
+    fun `manual sync after local mutation request does not enqueue duplicate sync`() = runTest {
+        calDavConfigRepository.seed(
+            enabled = true,
+            serverUrl = "https://example.com",
+            username = "user",
+            listName = "Shopping"
+        )
+        advanceUntilIdle()
+
+        viewModel.onInputValueChange("Milk")
+        viewModel.onAddItem()
+        advanceUntilIdle()
+
+        assertEquals(1, syncScheduler.requestCount)
+
+        viewModel.onManualSyncRequested()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isManualSync)
+        assertEquals(1, syncScheduler.requestCount)
+
+        syncScheduler.setSyncing(true)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isManualSync)
+        assertFalse(viewModel.uiState.value.isBackgroundSync)
+    }
+
+    @Test
+    fun `manual sync during background sync promotes to manual without duplicate request`() = runTest {
+        calDavConfigRepository.seed(
+            enabled = true,
+            serverUrl = "https://example.com",
+            username = "user",
+            listName = "Shopping"
+        )
+        advanceUntilIdle()
+
+        syncScheduler.setSyncing(true)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isBackgroundSync)
+        assertFalse(viewModel.uiState.value.isManualSync)
+        assertEquals(0, syncScheduler.requestCount)
+
+        viewModel.onManualSyncRequested()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isManualSync)
+        assertFalse(viewModel.uiState.value.isBackgroundSync)
+        assertEquals(0, syncScheduler.requestCount)
+
+        syncScheduler.setSyncing(false)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isManualSync)
+        assertFalse(viewModel.uiState.value.isBackgroundSync)
+    }
+
+    @Test
+    fun `isManualSync reflects manual sync request while scheduler is syncing`() = runTest {
+        calDavConfigRepository.seed(
+            enabled = true,
+            serverUrl = "https://example.com",
+            username = "user",
+            listName = "Shopping"
+        )
+        advanceUntilIdle()
+
+        syncScheduler.setSyncing(true)
+        viewModel.onManualSyncRequested()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isManualSync)
+        assertFalse(viewModel.uiState.value.isBackgroundSync)
+
+        syncScheduler.setSyncing(false)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isManualSync)
+        assertFalse(viewModel.uiState.value.isBackgroundSync)
     }
 
     @Test
@@ -335,7 +451,7 @@ class ShoppingListViewModelTest {
     }
 
     @Test
-    fun `onPullToRefresh when configured invokes sync`() = runTest {
+    fun `onManualSyncRequested when configured invokes sync`() = runTest {
         calDavConfigRepository.seed(
             enabled = true,
             serverUrl = "https://example.com",
@@ -344,30 +460,30 @@ class ShoppingListViewModelTest {
         )
         advanceUntilIdle()
 
-        viewModel.onPullToRefresh()
+        viewModel.onManualSyncRequested()
         advanceUntilIdle()
 
         assertEquals(1, syncScheduler.requestCount)
     }
 
     @Test
-    fun `onPullToRefresh when not configured does not invoke sync`() = runTest {
+    fun `onManualSyncRequested when not configured does not invoke sync`() = runTest {
         calDavConfigRepository.seed(enabled = false)
         advanceUntilIdle()
 
-        viewModel.onPullToRefresh()
+        viewModel.onManualSyncRequested()
         advanceUntilIdle()
 
         assertEquals(0, syncScheduler.requestCount)
     }
 
     @Test
-    fun `onPullToRefresh when not configured emits SyncNotConfigured event`() = runTest {
+    fun `onManualSyncRequested when not configured emits SyncNotConfigured event`() = runTest {
         calDavConfigRepository.seed(enabled = false)
         advanceUntilIdle()
 
         viewModel.uiEvents.test {
-            viewModel.onPullToRefresh()
+            viewModel.onManualSyncRequested()
             assertEquals(ShoppingListUiEvent.SyncNotConfigured, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }


### PR DESCRIPTION
## Summary

Restructures the shopping list view model so that the user can distinguish a **manual sync** (explicit user gesture) from a **background sync** (side effect of a local mutation or scheduler tick), and ensures local mutations no longer trigger the disruptive top-of-screen sync indicator.

## Changes

- `ShoppingListUiState` now exposes `isManualSync` and `isBackgroundSync` instead of the single `isSyncing`.
- Added `manualSyncLatch` + `hasPendingSyncRequest` state machine in `ShoppingListViewModel`.
- Renamed `onPullToRefresh()` → `onManualSyncRequested()`; updated all call sites.
- Pull-to-refresh indicator is now gated on `isManualSync` only.

## Overlap behavior

| Scenario | Result |
|---|---|
| Mutation during manual sync | `isManualSync` stays `true` until queue drains |
| Manual tap during background sync | Promotes to manual visual, no duplicate request |
| Mutation only | `isBackgroundSync = true`, spinner hidden |
| Manual sync only | `isManualSync = true`, spinner shown |

## Verification

- `./gradlew testDebugUnitTest` ✅
- `./gradlew lintDebug` ✅
- `./gradlew verifyDebugCoverage` ✅ (≥ 85%)

Closes #35