### PR TITLE
Add item icon design docs and update CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,3 +15,24 @@ The shopping list is the source of truth on the device. All mutations apply loca
 
 ### Sync configured
 The user has supplied valid CalDAV credentials and selected (or created) a target list. Until sync is configured, the sync badge is hidden — the settings cog is the only path to configuration.
+
+### Item icon
+A small visual marker shown next to a shopping item to help the user scan the list. The icon is **decorative only**: it has no functional role (no grouping, no sorting, no filtering, no stats). A wrong icon is mildly ugly; it never blocks the user. When the system has low confidence, it shows a neutral generic icon rather than guessing — silence is better than a wrong guess.
+
+The icon coverage is **grocery-first**: food, drinks, cleaning products, personal care, pet, and baby items get specific icons; anything outside that scope (hardware, electronics, clothing, etc.) falls through to the generic icon. Non-grocery is not a bug — it's the designed boundary.
+
+The icon is **derived state, never stored**: it is computed from the item name at render time, like a syntax-highlighting color. It is not part of the ShoppingItem model, not in the database schema, and not synced through CalDAV. Improving the dictionary later improves every item retroactively, with no migration or re-resolve pass.
+
+Day-one languages for icon resolution are **PT-BR and EN**. Both are loaded together regardless of system locale, because users routinely mix English brand and product names ("shampoo Pantene", "whey", "ração Whiskas") into Portuguese lists. Additional languages are pure data additions — the matcher does not know specific languages, only language packs.
+
+The icon system uses **~25 buckets** (medium granularity). Buckets are stable, language-independent identifiers (`fruit`, `vegetable`, `dairy`, `meat`, `fish`, `bread`, `grain`, `beverages-cold`, `beverages-hot`, `alcohol`, `frozen`, `snacks`, `sweets`, `condiments`, `oils`, `pantry-canned`, `cleaning`, `personal-care`, `pet`, `baby`, etc., plus `generic`). The icon for each bucket is decided once in code; the dictionary maps terms to buckets, never directly to icons. Adding or swapping an icon library is a one-file change.
+
+The matcher is **shallow by design**: normalize → exact match → alias match → token-head match → generic. No stemming, no fuzzy/Levenshtein, no embeddings, no ML. Plurals and inflections are absorbed by the aliases table, not by runtime morphology. Quantities and units (`2kg`, `500ml`, `pacote`, `2x`) are stripped during normalization so token-head match works on "arroz", not "2kg arroz". This guarantees lookups are pure HashMap reads, fully memoizable, and never produce a "creative" wrong icon — either the term is known, or the generic icon is shown.
+
+**No per-item user overrides in v1.** The icon is a pure function of the item name; if it's wrong, it's wrong everywhere that name appears, and it falls to the generic icon if confidence is too low. Overrides are deferred until real usage shows the matcher's coverage is genuinely insufficient — adding them later is a purely additive change (a single nullable column or side table); removing them after shipping would be breaking.
+
+The dictionary lives as **JSON files in `assets/`**, loaded once into an in-memory `HashMap<String, Bucket>` on first list render (off the main thread). The icon system never touches Room — the dictionary is static data, not persisted state. Updates to the dictionary ship in the APK; there is no first-launch seed path, no DAO, no migration story for icon data.
+
+The dictionary is built **hybrid**: a build-time script ingests Open Food Facts taxonomy as the broad base (filtered through a hand-written OFF-category-to-bucket map), then a per-language overlay file applies hand-curated corrections and PT-BR-specific additions on top. Re-ingesting OFF is a one-command refresh that never overwrites the overlay. The runtime only sees the final merged JSON.
+
+The item icon **replaces** the per-row state icon (no separate purchase-state glyph). State information — pending vs purchased, selected for batch action vs not — is carried by the section split, container color, text decoration, and row alpha; the icon is no longer load-bearing for state. Tap affordance for marking purchased is the whole-row click, not the icon. The generic icon is **always rendered** when the matcher misses, so the list's left edge stays aligned.

--- a/docs/adr/0001-item-icon-design.md
+++ b/docs/adr/0001-item-icon-design.md
@@ -1,0 +1,24 @@
+# Item icon as derived presentation, not stored data or control
+
+The grocery icon shown next to each shopping item is **derived from the item name at render time** and **replaces** the per-row purchase-state icon (radio button / check / history). Two linked decisions, one philosophy: the icon is *visual feedback on data*, never *data* itself and never *a tappable control*.
+
+## Why
+
+A future reader will see two things that look like bugs and aren't:
+
+1. **No `iconBucket` column on `ShoppingItem`, no entry in the CalDAV format, no Room migration for icons.** This is deliberate. Caching the bucket on the entity would buy negligible render-time speedup (HashMap lookup is sub-microsecond, memoizable) at the cost of a schema migration, a sync-format pollution question, a "stale icon after dictionary update" class of bugs, and a re-resolve pass when items arrive via CalDAV import. Treating the icon as derived state — like a syntax-highlighting color — keeps the data model and CalDAV payload identical to today and lets every dictionary improvement update existing items for free.
+
+2. **The radio-button / check / history state icon is gone, replaced by the grocery icon; the whole row is the tap target.** State (pending / selected / purchased) is already carried redundantly by the section split, container color animation, text decoration, and row alpha — the state icon was a fourth or fifth signal. The grocery icon adds *identity* information (what the thing is) which the state icon never carried, while the row-click affordance covers what the state icon used to invite. Bring! and AnyList work the same way.
+
+## Considered alternatives
+
+- **Cache the icon bucket on the entity.** Rejected: zero render-time win after memoization, real schema and sync cost.
+- **Two leading icons side-by-side (`[state] [grocery] text`).** Rejected: visually heavier, doubles iconography, doesn't pay for itself once you accept that section + color + alpha already convey state.
+- **Grocery icon on the trailing edge.** Rejected: trailing slot conventionally signals "action" (delete, more); putting a descriptor there invites mis-taps and reserves the slot from future actions.
+- **No icon when matcher misses.** Rejected: a jagged left edge is uglier than a row of consistent icons with one being a faint generic basket. Generic is always rendered.
+
+## Consequences
+
+- **Per-item user overrides become a real change** if we ever ship them — they re-introduce stored state and break the "icon is purely a function of name" invariant. Deferring overrides was a deliberate part of this decision.
+- **The selected-row container color must be visually unmistakable on its own**, since the `Check` icon is no longer there to reinforce batch-selection state.
+- **The matcher must be fast and side-effect-free.** Anything heavier than a HashMap lookup against a normalized term breaks the "compute on every render" assumption. This is why the matcher is shallow by design (no stemming, no fuzzy, no ML).


### PR DESCRIPTION
This pull request introduces the design and implementation plan for the new item icon system in the shopping list app. The icon system provides a small, decorative icon next to each shopping item, derived from the item name at render time, and replaces the previous per-row purchase-state icon. The changes clarify the rationale, design boundaries, and technical approach for this feature, emphasizing that icons are derived presentation, not stored data.

Item Icon System Design and Rationale:

* Added a detailed description in `CONTEXT.md` of the new item icon feature, including its decorative-only purpose, grocery-first coverage, language support (PT-BR and EN), bucket-based mapping, and shallow, fast matching algorithm. It also explains that the icon is always computed at render time and never stored in the data model or synced.
* Added an architectural decision record (`docs/adr/0001-item-icon-design.md`) documenting why the icon is derived state, not stored, and why it replaces the old state icon. The ADR also discusses considered alternatives, consequences, and design tradeoffs for future maintainers.