### PR TITLE
feat(icon): tracer bullet auto grocery icon path

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListItemIconTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListItemIconTest.kt
@@ -1,0 +1,134 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.jhow.shopplist.domain.icon.IconBucket
+import com.jhow.shopplist.domain.icon.IconMatcher
+import com.jhow.shopplist.domain.model.ShoppingItem
+import com.jhow.shopplist.domain.model.SyncStatus
+import com.jhow.shopplist.presentation.icon.IconResolver
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShoppingListItemIconTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val fakeIconResolver = IconResolver(
+        object : IconMatcher {
+            override fun match(itemName: String): IconBucket =
+                if (itemName.equals("milk", ignoreCase = true)) {
+                    IconBucket.DAIRY
+                } else {
+                    IconBucket.GENERIC
+                }
+        }
+    )
+
+    @Test
+    fun pendingRowRendersIcon() {
+        composeRule.setContent {
+            ShoppingListScreen(
+                uiState = ShoppingListUiState(
+                    pendingItems = listOf(sampleItem("1", "Milk")),
+                    selectedIds = emptySet()
+                ),
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("1")).assertIsDisplayed()
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.ITEM_ICON).assertCountEquals(1)
+    }
+
+    @Test
+    fun purchasedRowRendersIcon() {
+        composeRule.setContent {
+            ShoppingListScreen(
+                uiState = ShoppingListUiState(
+                    purchasedItems = listOf(sampleItem("2", "Bread", isPurchased = true))
+                ),
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.purchasedItem("2")).assertIsDisplayed()
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.ITEM_ICON).assertCountEquals(1)
+    }
+
+    @Test
+    fun clickingPendingRowStillTogglesSelection() {
+        var clicked = false
+        composeRule.setContent {
+            ShoppingListScreen(
+                uiState = ShoppingListUiState(
+                    pendingItems = listOf(sampleItem("3", "Milk"))
+                ),
+                snackbarHostState = SnackbarHostState(),
+                itemCallbacks = ShoppingListItemCallbacks(
+                    onPendingItemClick = { clicked = true }
+                ),
+                iconResolver = fakeIconResolver
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("3")).performClick()
+        composeRule.waitForIdle()
+
+        assertTrue("Pending item click callback should fire", clicked)
+    }
+
+    @Test
+    fun clickingPurchasedRowStillRestoresItem() {
+        var clicked = false
+        composeRule.setContent {
+            ShoppingListScreen(
+                uiState = ShoppingListUiState(
+                    purchasedItems = listOf(sampleItem("4", "Bread", isPurchased = true))
+                ),
+                snackbarHostState = SnackbarHostState(),
+                itemCallbacks = ShoppingListItemCallbacks(
+                    onPurchasedItemClick = { clicked = true }
+                ),
+                iconResolver = fakeIconResolver
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.purchasedItem("4")).performClick()
+        composeRule.waitForIdle()
+
+        assertTrue("Purchased item click callback should fire", clicked)
+    }
+
+    private fun sampleItem(
+        id: String,
+        name: String,
+        isPurchased: Boolean = false
+    ): ShoppingItem = ShoppingItem(
+        id = id,
+        name = name,
+        isPurchased = isPurchased,
+        purchaseCount = 0,
+        createdAt = 0L,
+        updatedAt = 0L,
+        isDeleted = false,
+        syncStatus = SyncStatus.SYNCED
+    )
+}

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.jhow.shopplist.domain.icon.IconBucket
+import com.jhow.shopplist.domain.icon.IconMatcher
+import com.jhow.shopplist.presentation.icon.IconResolver
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -17,15 +20,23 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ShoppingListTopBarTest {
+
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val fakeIconResolver = IconResolver(
+        object : IconMatcher {
+            override fun match(itemName: String): IconBucket = IconBucket.GENERIC
+        }
+    )
 
     @Test
     fun topAppBar_showsSettingsGearIcon_withTestTag() {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(),
-                snackbarHostState = SnackbarHostState()
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -38,7 +49,8 @@ class ShoppingListTopBarTest {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(),
-                snackbarHostState = SnackbarHostState()
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -51,7 +63,8 @@ class ShoppingListTopBarTest {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(isSyncConfigured = false),
-                snackbarHostState = SnackbarHostState()
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -65,7 +78,8 @@ class ShoppingListTopBarTest {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(isSyncConfigured = true),
-                snackbarHostState = SnackbarHostState()
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -84,7 +98,8 @@ class ShoppingListTopBarTest {
                 snackbarHostState = SnackbarHostState(),
                 syncCallbacks = ShoppingListSyncCallbacks(
                     onSyncSettingsClicked = { settingsClicked = true }
-                )
+                ),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -103,7 +118,8 @@ class ShoppingListTopBarTest {
                 snackbarHostState = SnackbarHostState(),
                 syncCallbacks = ShoppingListSyncCallbacks(
                     onManualSyncRequested = { manualSyncInvoked = true }
-                )
+                ),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -119,7 +135,8 @@ class ShoppingListTopBarTest {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(isSyncConfigured = true, isManualSync = true),
-                snackbarHostState = SnackbarHostState()
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
@@ -133,7 +150,8 @@ class ShoppingListTopBarTest {
         composeRule.setContent {
             ShoppingListScreen(
                 uiState = ShoppingListUiState(isSyncConfigured = true, isBackgroundSync = true),
-                snackbarHostState = SnackbarHostState()
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()

--- a/app/src/main/java/com/jhow/shopplist/MainActivity.kt
+++ b/app/src/main/java/com/jhow/shopplist/MainActivity.kt
@@ -12,12 +12,18 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.jhow.shopplist.navigation.Routes
 import com.jhow.shopplist.presentation.caldavconfig.CalDavConfigRoute
+import com.jhow.shopplist.presentation.icon.IconResolver
 import com.jhow.shopplist.presentation.shoppinglist.ShoppingListRoute
 import com.jhow.shopplist.ui.theme.JhowShoppListTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var iconResolver: IconResolver
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -33,7 +39,8 @@ class MainActivity : ComponentActivity() {
                             ShoppingListRoute(
                                 onNavigateToCalDavConfig = {
                                     navController.navigate(Routes.CALDAV_CONFIG)
-                                }
+                                },
+                                iconResolver = iconResolver
                             )
                         }
                         composable(Routes.CALDAV_CONFIG) {

--- a/app/src/main/java/com/jhow/shopplist/di/IconModule.kt
+++ b/app/src/main/java/com/jhow/shopplist/di/IconModule.kt
@@ -1,0 +1,50 @@
+package com.jhow.shopplist.di
+
+import com.jhow.shopplist.domain.icon.DefaultIconMatcher
+import com.jhow.shopplist.domain.icon.DefaultTextNormalizer
+import com.jhow.shopplist.domain.icon.IconBucket
+import com.jhow.shopplist.domain.icon.IconMatcher
+import com.jhow.shopplist.domain.icon.TextNormalizer
+import com.jhow.shopplist.presentation.icon.IconResolver
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object IconModule {
+
+    @Provides
+    @Singleton
+    fun provideTextNormalizer(): TextNormalizer = DefaultTextNormalizer()
+
+    @Provides
+    @Singleton
+    fun provideIconMatcher(normalizer: TextNormalizer): IconMatcher {
+        val dictionary = mapOf(
+            "leite" to IconBucket.DAIRY,
+            "milk" to IconBucket.DAIRY,
+            "iogurte" to IconBucket.DAIRY,
+            "yogurt" to IconBucket.DAIRY,
+            "maçã" to IconBucket.FRUIT,
+            "maca" to IconBucket.FRUIT,
+            "apple" to IconBucket.FRUIT,
+            "banana" to IconBucket.FRUIT,
+            "pão" to IconBucket.BREAD,
+            "pao" to IconBucket.BREAD,
+            "bread" to IconBucket.BREAD,
+            "arroz" to IconBucket.PANTRY_CANNED,
+            "rice" to IconBucket.PANTRY_CANNED,
+            "feijão" to IconBucket.PANTRY_CANNED,
+            "feijao" to IconBucket.PANTRY_CANNED,
+            "beans" to IconBucket.PANTRY_CANNED
+        )
+        return DefaultIconMatcher(dictionary, normalizer)
+    }
+
+    @Provides
+    @Singleton
+    fun provideIconResolver(matcher: IconMatcher): IconResolver = IconResolver(matcher)
+}

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/IconBucket.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/IconBucket.kt
@@ -1,0 +1,9 @@
+package com.jhow.shopplist.domain.icon
+
+enum class IconBucket {
+    DAIRY,
+    FRUIT,
+    BREAD,
+    PANTRY_CANNED,
+    GENERIC
+}

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
@@ -1,0 +1,15 @@
+package com.jhow.shopplist.domain.icon
+
+interface IconMatcher {
+    fun match(itemName: String): IconBucket
+}
+
+class DefaultIconMatcher(
+    private val dictionary: Map<String, IconBucket>,
+    private val normalizer: TextNormalizer
+) : IconMatcher {
+    override fun match(itemName: String): IconBucket {
+        val normalized = normalizer.normalize(itemName)
+        return dictionary[normalized] ?: IconBucket.GENERIC
+    }
+}

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/TextNormalizer.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/TextNormalizer.kt
@@ -1,0 +1,9 @@
+package com.jhow.shopplist.domain.icon
+
+interface TextNormalizer {
+    fun normalize(text: String): String
+}
+
+class DefaultTextNormalizer : TextNormalizer {
+    override fun normalize(text: String): String = text.trim().lowercase()
+}

--- a/app/src/main/java/com/jhow/shopplist/presentation/icon/BucketIcons.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/icon/BucketIcons.kt
@@ -1,0 +1,20 @@
+package com.jhow.shopplist.presentation.icon
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BreakfastDining
+import androidx.compose.material.icons.rounded.Kitchen
+import androidx.compose.material.icons.rounded.ShoppingBasket
+import androidx.compose.material.icons.rounded.Spa
+import androidx.compose.material.icons.rounded.WaterDrop
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.jhow.shopplist.domain.icon.IconBucket
+
+object BucketIcons {
+    fun forBucket(bucket: IconBucket): ImageVector = when (bucket) {
+        IconBucket.DAIRY -> Icons.Rounded.WaterDrop
+        IconBucket.FRUIT -> Icons.Rounded.Spa
+        IconBucket.BREAD -> Icons.Rounded.BreakfastDining
+        IconBucket.PANTRY_CANNED -> Icons.Rounded.Kitchen
+        IconBucket.GENERIC -> Icons.Rounded.ShoppingBasket
+    }
+}

--- a/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
@@ -1,0 +1,15 @@
+package com.jhow.shopplist.presentation.icon
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.jhow.shopplist.domain.icon.IconMatcher
+
+class IconResolver(private val matcher: IconMatcher) {
+    private val cache = mutableMapOf<String, ImageVector>()
+
+    fun resolveIcon(itemName: String): ImageVector {
+        return cache.getOrPut(itemName) {
+            val bucket = matcher.match(itemName)
+            BucketIcons.forBucket(bucket)
+        }
+    }
+}

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -34,8 +34,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AddTask
 import androidx.compose.material.icons.rounded.Check
-import androidx.compose.material.icons.rounded.History
-import androidx.compose.material.icons.rounded.RadioButtonUnchecked
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.ShoppingBag
 import androidx.compose.material.icons.rounded.Sync
@@ -88,6 +86,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jhow.shopplist.R
 import com.jhow.shopplist.domain.model.ShoppingItem
+import com.jhow.shopplist.presentation.icon.IconResolver
 
 class ShoppingListInputCallbacks(
     val onValueChange: (String) -> Unit = {},
@@ -133,6 +132,8 @@ private data class ShoppingListContentLayout(
 internal val shoppingListWideSurfaceShape: Shape = RoundedCornerShape(percent = 50)
 
 internal enum class ShoppingListColorRole {
+    PrimaryContainer,
+    OnPrimaryContainer,
     SecondaryContainer,
     OnSecondaryContainer,
     SurfaceContainerLow,
@@ -147,8 +148,8 @@ internal data class PendingItemRowColorRoles(
 internal fun pendingItemRowColorRoles(isSelected: Boolean): PendingItemRowColorRoles =
     if (isSelected) {
         PendingItemRowColorRoles(
-            container = ShoppingListColorRole.SecondaryContainer,
-            content = ShoppingListColorRole.OnSecondaryContainer
+            container = ShoppingListColorRole.PrimaryContainer,
+            content = ShoppingListColorRole.OnPrimaryContainer
         )
     } else {
         PendingItemRowColorRoles(
@@ -159,6 +160,8 @@ internal fun pendingItemRowColorRoles(isSelected: Boolean): PendingItemRowColorR
 
 @Composable
 private fun ShoppingListColorRole.resolve() = when (this) {
+    ShoppingListColorRole.PrimaryContainer -> MaterialTheme.colorScheme.primaryContainer
+    ShoppingListColorRole.OnPrimaryContainer -> MaterialTheme.colorScheme.onPrimaryContainer
     ShoppingListColorRole.SecondaryContainer -> MaterialTheme.colorScheme.secondaryContainer
     ShoppingListColorRole.OnSecondaryContainer -> MaterialTheme.colorScheme.onSecondaryContainer
     ShoppingListColorRole.SurfaceContainerLow -> MaterialTheme.colorScheme.surfaceContainerLow
@@ -168,7 +171,8 @@ private fun ShoppingListColorRole.resolve() = when (this) {
 @Composable
 fun ShoppingListRoute(
     onNavigateToCalDavConfig: () -> Unit,
-    viewModel: ShoppingListViewModel = hiltViewModel()
+    viewModel: ShoppingListViewModel = hiltViewModel(),
+    iconResolver: IconResolver
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -201,7 +205,8 @@ fun ShoppingListRoute(
         snackbarHostState = snackbarHostState,
         inputCallbacks = inputCallbacks,
         itemCallbacks = itemCallbacks,
-        syncCallbacks = syncCallbacks
+        syncCallbacks = syncCallbacks,
+        iconResolver = iconResolver
     )
 }
 
@@ -214,6 +219,7 @@ fun ShoppingListScreen(
     inputCallbacks: ShoppingListInputCallbacks = ShoppingListInputCallbacks(),
     itemCallbacks: ShoppingListItemCallbacks = ShoppingListItemCallbacks(),
     syncCallbacks: ShoppingListSyncCallbacks = ShoppingListSyncCallbacks(),
+    iconResolver: IconResolver
 ) {
     val focusManager = LocalFocusManager.current
     var inputBarContentHeightPx by remember { mutableIntStateOf(0) }
@@ -250,7 +256,8 @@ fun ShoppingListScreen(
             ),
             inputCallbacks = inputCallbacks,
             itemCallbacks = itemCallbacks,
-            onInputBarHeightChanged = { inputBarContentHeightPx = it }
+            onInputBarHeightChanged = { inputBarContentHeightPx = it },
+            iconResolver = iconResolver
         )
     }
 }
@@ -262,7 +269,8 @@ private fun ShoppingListScreenContent(
     layout: ShoppingListContentLayout,
     inputCallbacks: ShoppingListInputCallbacks,
     itemCallbacks: ShoppingListItemCallbacks,
-    onInputBarHeightChanged: (Int) -> Unit
+    onInputBarHeightChanged: (Int) -> Unit,
+    iconResolver: IconResolver
 ) {
     Box(
         modifier = Modifier
@@ -272,7 +280,8 @@ private fun ShoppingListScreenContent(
         ShoppingItemsContent(
             uiState = uiState,
             itemCallbacks = itemCallbacks,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
+            iconResolver = iconResolver
         )
 
         if (uiState.isManualSync) {
@@ -518,7 +527,8 @@ private fun BulkPurchaseFab(
 private fun ShoppingItemsContent(
     uiState: ShoppingListUiState,
     itemCallbacks: ShoppingListItemCallbacks,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    iconResolver: IconResolver
 ) {
     val swipeResetTrigger = uiState.itemPendingDeletion?.id.orEmpty()
     val emptyPendingTitle = stringResource(R.string.empty_pending_title)
@@ -541,7 +551,8 @@ private fun ShoppingItemsContent(
             selectedIds = uiState.selectedIds,
             swipeResetTrigger = swipeResetTrigger,
             itemCallbacks = itemCallbacks,
-            emptyPendingTitle = emptyPendingTitle
+            emptyPendingTitle = emptyPendingTitle,
+            iconResolver = iconResolver
         )
 
         item(key = ShoppingListTestTags.SECTION_DIVIDER) {
@@ -559,7 +570,8 @@ private fun ShoppingItemsContent(
             purchasedItems = uiState.purchasedItems,
             swipeResetTrigger = swipeResetTrigger,
             itemCallbacks = itemCallbacks,
-            emptyPurchasedTitle = emptyPurchasedTitle
+            emptyPurchasedTitle = emptyPurchasedTitle,
+            iconResolver = iconResolver
         )
     }
 }
@@ -569,7 +581,8 @@ private fun androidx.compose.foundation.lazy.LazyListScope.pendingItemsSection(
     selectedIds: Set<String>,
     swipeResetTrigger: String,
     itemCallbacks: ShoppingListItemCallbacks,
-    emptyPendingTitle: String
+    emptyPendingTitle: String,
+    iconResolver: IconResolver
 ) {
     if (pendingItems.isEmpty()) {
         item(key = ShoppingListTestTags.EMPTY_STATE) {
@@ -581,7 +594,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.pendingItemsSection(
         return
     }
 
-    items(
+        items(
         items = pendingItems,
         key = { item -> item.id }
     ) { item ->
@@ -591,6 +604,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.pendingItemsSection(
             onClick = { itemCallbacks.onPendingItemClick(item.id) },
             onDeleteRequested = { itemCallbacks.onDeleteItemRequested(item) },
             swipeResetTrigger = swipeResetTrigger,
+            iconResolver = iconResolver,
             modifier = Modifier.animateItem()
         )
     }
@@ -600,7 +614,8 @@ private fun androidx.compose.foundation.lazy.LazyListScope.purchasedItemsSection
     purchasedItems: List<ShoppingItem>,
     swipeResetTrigger: String,
     itemCallbacks: ShoppingListItemCallbacks,
-    emptyPurchasedTitle: String
+    emptyPurchasedTitle: String,
+    iconResolver: IconResolver
 ) {
     if (purchasedItems.isEmpty()) {
         item(key = "purchased_empty") {
@@ -620,6 +635,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.purchasedItemsSection
             onClick = { itemCallbacks.onPurchasedItemClick(item.id) },
             onDeleteRequested = { itemCallbacks.onDeleteItemRequested(item) },
             swipeResetTrigger = swipeResetTrigger,
+            iconResolver = iconResolver,
             modifier = Modifier.animateItem()
         )
     }
@@ -691,6 +707,7 @@ private fun PendingItemRow(
     onClick: () -> Unit,
     onDeleteRequested: () -> Unit,
     swipeResetTrigger: String,
+    iconResolver: IconResolver,
     modifier: Modifier = Modifier
 ) {
     val colorRoles = pendingItemRowColorRoles(isSelected)
@@ -708,7 +725,7 @@ private fun PendingItemRow(
     ShoppingItemRow(
         name = item.name,
         visuals = ShoppingItemRowVisuals(
-            leadingIcon = if (isSelected) Icons.Rounded.Check else Icons.Rounded.RadioButtonUnchecked,
+            leadingIcon = iconResolver.resolveIcon(item.name),
             containerColor = containerColor,
             contentColor = contentColor
         ),
@@ -731,12 +748,13 @@ private fun PurchasedItemRow(
     onClick: () -> Unit,
     onDeleteRequested: () -> Unit,
     swipeResetTrigger: String,
+    iconResolver: IconResolver,
     modifier: Modifier = Modifier
 ) {
     ShoppingItemRow(
         name = item.name,
         visuals = ShoppingItemRowVisuals(
-            leadingIcon = Icons.Rounded.History,
+            leadingIcon = iconResolver.resolveIcon(item.name),
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
             contentColor = MaterialTheme.colorScheme.onSurface,
             textDecoration = TextDecoration.LineThrough,
@@ -805,7 +823,9 @@ private fun ShoppingItemRow(
                 imageVector = visuals.leadingIcon,
                 contentDescription = null,
                 tint = visuals.contentColor,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier
+                    .size(20.dp)
+                    .testTag(ShoppingListTestTags.ITEM_ICON)
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
@@ -37,4 +37,6 @@ object ShoppingListTestTags {
     fun swipePurchasedItem(id: String): String = "swipe_purchased_item_$id"
 
     fun suggestionItem(name: String): String = "suggestion_item_$name"
+
+    const val ITEM_ICON = "item_icon"
 }

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
@@ -1,0 +1,88 @@
+package com.jhow.shopplist.domain.icon
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IconMatcherTest {
+
+    private val dictionary = mapOf(
+        "leite" to IconBucket.DAIRY,
+        "milk" to IconBucket.DAIRY,
+        "iogurte" to IconBucket.DAIRY,
+        "yogurt" to IconBucket.DAIRY,
+        "maçã" to IconBucket.FRUIT,
+        "maca" to IconBucket.FRUIT,
+        "apple" to IconBucket.FRUIT,
+        "banana" to IconBucket.FRUIT,
+        "pão" to IconBucket.BREAD,
+        "pao" to IconBucket.BREAD,
+        "bread" to IconBucket.BREAD,
+        "arroz" to IconBucket.PANTRY_CANNED,
+        "rice" to IconBucket.PANTRY_CANNED,
+        "feijão" to IconBucket.PANTRY_CANNED,
+        "feijao" to IconBucket.PANTRY_CANNED,
+        "beans" to IconBucket.PANTRY_CANNED
+    )
+
+    private val normalizer = DefaultTextNormalizer()
+    private val matcher = DefaultIconMatcher(dictionary, normalizer)
+
+    @Test
+    fun `exact match returns corresponding bucket`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("leite"))
+    }
+
+    @Test
+    fun `exact match with different casing returns bucket`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("Leite"))
+    }
+
+    @Test
+    fun `exact match with whitespace returns bucket`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("  leite  "))
+    }
+
+    @Test
+    fun `unknown term returns generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("parafuso"))
+    }
+
+    @Test
+    fun `unknown english term returns generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("screwdriver"))
+    }
+
+    @Test
+    fun `empty string returns generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match(""))
+    }
+
+    @Test
+    fun `fruit terms resolve to fruit bucket`() {
+        assertEquals(IconBucket.FRUIT, matcher.match("maçã"))
+        assertEquals(IconBucket.FRUIT, matcher.match("maca"))
+        assertEquals(IconBucket.FRUIT, matcher.match("apple"))
+    }
+
+    @Test
+    fun `bread terms resolve to bread bucket`() {
+        assertEquals(IconBucket.BREAD, matcher.match("pão"))
+        assertEquals(IconBucket.BREAD, matcher.match("pao"))
+        assertEquals(IconBucket.BREAD, matcher.match("bread"))
+    }
+
+    @Test
+    fun `pantry terms resolve to pantry canned bucket`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("arroz"))
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("rice"))
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijão"))
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijao"))
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("beans"))
+    }
+
+    @Test
+    fun `mixed case pantry term resolves correctly`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("Arroz"))
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("  Feijao  "))
+    }
+}

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/TextNormalizerTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/TextNormalizerTest.kt
@@ -1,0 +1,59 @@
+package com.jhow.shopplist.domain.icon
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TextNormalizerTest {
+
+    private val normalizer = DefaultTextNormalizer()
+
+    @Test
+    fun `lowercases simple term`() {
+        assertEquals("leite", normalizer.normalize("Leite"))
+    }
+
+    @Test
+    fun `trims leading and trailing whitespace`() {
+        assertEquals("leite", normalizer.normalize("  leite  "))
+    }
+
+    @Test
+    fun `trims and lowercases combined`() {
+        assertEquals("leite integral", normalizer.normalize("  Leite Integral  "))
+    }
+
+    @Test
+    fun `empty string returns empty string`() {
+        assertEquals("", normalizer.normalize(""))
+    }
+
+    @Test
+    fun `whitespace-only string returns empty string`() {
+        assertEquals("", normalizer.normalize("   "))
+    }
+
+    @Test
+    fun `already normalized term stays unchanged`() {
+        assertEquals("arroz", normalizer.normalize("arroz"))
+    }
+
+    @Test
+    fun `mixed casing is fully lowercased`() {
+        assertEquals("coca-cola", normalizer.normalize("CoCa-CoLa"))
+    }
+
+    @Test
+    fun `internal whitespace is preserved`() {
+        assertEquals("pao de queijo", normalizer.normalize("Pao de Queijo"))
+    }
+
+    @Test
+    fun `single character is lowercased`() {
+        assertEquals("a", normalizer.normalize("A"))
+    }
+
+    @Test
+    fun `numeric characters are preserved`() {
+        assertEquals("2kg arroz", normalizer.normalize("2kg Arroz"))
+    }
+}

--- a/app/src/test/java/com/jhow/shopplist/presentation/icon/BucketIconsTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/icon/BucketIconsTest.kt
@@ -1,0 +1,18 @@
+package com.jhow.shopplist.presentation.icon
+
+import com.jhow.shopplist.domain.icon.IconBucket
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class BucketIconsTest {
+
+    @Test
+    fun `every icon bucket maps to a non-null image vector`() {
+        IconBucket.entries.forEach { bucket ->
+            assertNotNull(
+                "Bucket $bucket should map to a non-null ImageVector",
+                BucketIcons.forBucket(bucket)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/jhow/shopplist/presentation/icon/IconResolverTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/icon/IconResolverTest.kt
@@ -1,0 +1,39 @@
+package com.jhow.shopplist.presentation.icon
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ShoppingBasket
+import androidx.compose.material.icons.rounded.WaterDrop
+import com.jhow.shopplist.domain.icon.DefaultIconMatcher
+import com.jhow.shopplist.domain.icon.DefaultTextNormalizer
+import com.jhow.shopplist.domain.icon.IconBucket
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IconResolverTest {
+
+    private val dictionary = mapOf(
+        "leite" to IconBucket.DAIRY,
+        "milk" to IconBucket.DAIRY
+    )
+    private val matcher = DefaultIconMatcher(dictionary, DefaultTextNormalizer())
+    private val resolver = IconResolver(matcher)
+
+    @Test
+    fun `resolves known item to its bucket icon`() {
+        val icon = resolver.resolveIcon("leite")
+        assertEquals(BucketIcons.forBucket(IconBucket.DAIRY), icon)
+    }
+
+    @Test
+    fun `resolves unknown item to generic icon`() {
+        val icon = resolver.resolveIcon("parafuso")
+        assertEquals(BucketIcons.forBucket(IconBucket.GENERIC), icon)
+    }
+
+    @Test
+    fun `memoizes repeated lookups`() {
+        val icon1 = resolver.resolveIcon("leite")
+        val icon2 = resolver.resolveIcon("leite")
+        assertEquals(icon1, icon2)
+    }
+}

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenVisualsTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenVisualsTest.kt
@@ -6,11 +6,11 @@ import org.junit.Test
 
 class ShoppingListScreenVisualsTest {
     @Test
-    fun `selected pending rows use secondary container colors`() {
+    fun `selected pending rows use primary container colors`() {
         assertEquals(
             PendingItemRowColorRoles(
-                container = ShoppingListColorRole.SecondaryContainer,
-                content = ShoppingListColorRole.OnSecondaryContainer
+                container = ShoppingListColorRole.PrimaryContainer,
+                content = ShoppingListColorRole.OnPrimaryContainer
             ),
             pendingItemRowColorRoles(isSelected = true)
         )


### PR DESCRIPTION
Closes #41
Related to #40

## Summary

Tracer-bullet end-to-end implementation of the auto grocery icon path. Wires up the full layer cake — `IconBucket`, `BucketIcons`, `IconMatcher`, `TextNormalizer`, `IconResolver`, UI consumption — with a deliberately tiny vocabulary (~15 PT-BR + EN terms) so the architectural shape is proven before any JSON asset or data pipeline work.

## What changed

### Domain layer (`domain/icon`)
- `IconBucket` enum: `dairy`, `fruit`, `bread`, `pantry-canned`, `generic`
- `TextNormalizer` / `DefaultTextNormalizer` — lowercase + trim
- `IconMatcher` / `DefaultIconMatcher` — exact-match lookup against an in-code `Map<String, IconBucket>`, falls back to `generic`

### Presentation layer (`presentation/icon`)
- `BucketIcons` — maps every `IconBucket` to a non-null `ImageVector` from `material-icons-extended`
- `IconResolver` — orchestrator with in-memory memoization; exposes `resolveIcon(itemName: String): ImageVector`

### DI
- `IconModule` — Hilt `@Module` wiring `TextNormalizer` → `IconMatcher` → `IconResolver` as singletons

### UI integration
- `PendingItemRow` and `PurchasedItemRow` now render the resolved grocery icon instead of the old state icons (`RadioButtonUnchecked`/`Check`/`History`)
- Whole-row tap target for marking purchased/unpurchased is unchanged
- Selected-row background bumped from `SecondaryContainer` to `PrimaryContainer` so batch-selection remains unmistakable without the `Check` icon helper
- `MainActivity` injects `IconResolver` and passes it down to `ShoppingListRoute`

### Tests
- `TextNormalizerTest` — 10 table-driven cases
- `IconMatcherTest` — 10+ cases covering exact match, case insensitivity, whitespace, fallback, PT-BR and EN terms
- `BucketIconsTest` — guard test that every `IconBucket` maps to a non-null `ImageVector`
- `IconResolverTest` — smoke test for resolution and memoization
- `ShoppingListItemIconTest` — Compose UI test verifying icon renders and tap behavior preserved
- `ShoppingListScreenVisualsTest` updated for the new `PrimaryContainer` selected color

## Acceptance criteria
- [x] `IconBucket` enum exists with at least `dairy`, `fruit`, `bread`, `pantry-canned`, `generic`
- [x] `BucketIcons` maps each defined bucket to a non-null `ImageVector`
- [x] `TextNormalizer` does lowercase + trim
- [x] `IconMatcher` does exact-match lookup and falls back to `generic`
- [x] `IconResolver` exposes `resolveIcon(itemName: String): ImageVector`
- [x] `PendingItemRow` renders the resolved icon (no longer `RadioButtonUnchecked`/`Check`)
- [x] `PurchasedItemRow` renders the resolved icon with strikethrough + 0.6 alpha intact
- [x] Whole-row click still marks an item purchased / unpurchased
- [x] Selected-row container color is visually unmistakable (`PrimaryContainer`)
- [x] Generic icon renders for unknown items so the list's left edge stays aligned
- [x] Unit tests cover `TextNormalizer` and `IconMatcher`
- [x] No changes to `ShoppingItem`, Room schema, or CalDAV payload
- [x] `./gradlew lintDebug` and `./gradlew testDebugUnitTest` pass
- [x] Coverage stays ≥ 85%