### PR TITLE
feat(icon): move dictionary to JSON assets with off-main-thread loader

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -306,6 +306,7 @@ dependencies {
     }
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.hilt.work)

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListItemIconTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListItemIconTest.kt
@@ -33,6 +33,8 @@ class ShoppingListItemIconTest {
                 } else {
                     IconBucket.GENERIC
                 }
+
+            override fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean = false
         }
     )
 

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListItemIconTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListItemIconTest.kt
@@ -51,7 +51,7 @@ class ShoppingListItemIconTest {
         composeRule.waitForIdle()
 
         composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("1")).assertIsDisplayed()
-        composeRule.onAllNodesWithTag(ShoppingListTestTags.ITEM_ICON).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.ITEM_ICON, useUnmergedTree = true).assertCountEquals(1)
     }
 
     @Test
@@ -68,7 +68,7 @@ class ShoppingListItemIconTest {
         composeRule.waitForIdle()
 
         composeRule.onNodeWithTag(ShoppingListTestTags.purchasedItem("2")).assertIsDisplayed()
-        composeRule.onAllNodesWithTag(ShoppingListTestTags.ITEM_ICON).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.ITEM_ICON, useUnmergedTree = true).assertCountEquals(1)
     }
 
     @Test

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
@@ -27,6 +27,7 @@ class ShoppingListTopBarTest {
     private val fakeIconResolver = IconResolver(
         object : IconMatcher {
             override fun match(itemName: String): IconBucket = IconBucket.GENERIC
+            override fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean = false
         }
     )
 

--- a/app/src/main/assets/icons/dictionary-en.json
+++ b/app/src/main/assets/icons/dictionary-en.json
@@ -1,0 +1,9 @@
+{
+  "milk": "dairy",
+  "yogurt": "dairy",
+  "apple": "fruit",
+  "banana": "fruit",
+  "bread": "bread",
+  "rice": "pantry-canned",
+  "beans": "pantry-canned"
+}

--- a/app/src/main/assets/icons/dictionary-pt.json
+++ b/app/src/main/assets/icons/dictionary-pt.json
@@ -1,0 +1,11 @@
+{
+  "leite": "dairy",
+  "iogurte": "dairy",
+  "maçã": "fruit",
+  "maca": "fruit",
+  "pão": "bread",
+  "pao": "bread",
+  "arroz": "pantry-canned",
+  "feijão": "pantry-canned",
+  "feijao": "pantry-canned"
+}

--- a/app/src/main/java/com/jhow/shopplist/MainActivity.kt
+++ b/app/src/main/java/com/jhow/shopplist/MainActivity.kt
@@ -1,31 +1,50 @@
 package com.jhow.shopplist
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.jhow.shopplist.data.icon.DictionaryLoader
+import com.jhow.shopplist.domain.icon.DefaultIconMatcher
 import com.jhow.shopplist.navigation.Routes
 import com.jhow.shopplist.presentation.caldavconfig.CalDavConfigRoute
 import com.jhow.shopplist.presentation.icon.IconResolver
 import com.jhow.shopplist.presentation.shoppinglist.ShoppingListRoute
 import com.jhow.shopplist.ui.theme.JhowShoppListTheme
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.IOException
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.serialization.SerializationException
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    companion object {
+        private const val TAG = "MainActivity"
+    }
+
     @Inject
     lateinit var iconResolver: IconResolver
 
+    @Inject
+    lateinit var dictionaryLoader: DictionaryLoader
+
+    @Inject
+    lateinit var defaultIconMatcher: DefaultIconMatcher
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        loadIconDictionary()
         enableEdgeToEdge()
         setContent {
             JhowShoppListTheme {
@@ -52,6 +71,29 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun loadIconDictionary() {
+        lifecycleScope.launch {
+            val dictionary = try {
+                dictionaryLoader.load()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: IOException) {
+                Log.w(TAG, "Failed to load icon dictionary, using generic icons", error)
+                return@launch
+            } catch (error: SerializationException) {
+                Log.w(TAG, "Failed to load icon dictionary, using generic icons", error)
+                return@launch
+            } catch (error: IllegalArgumentException) {
+                Log.w(TAG, "Failed to load icon dictionary, using generic icons", error)
+                return@launch
+            }
+            val dictionaryChanged = defaultIconMatcher.updateDictionary(dictionary)
+            if (dictionaryChanged) {
+                iconResolver.clearCache()
             }
         }
     }

--- a/app/src/main/java/com/jhow/shopplist/MainActivity.kt
+++ b/app/src/main/java/com/jhow/shopplist/MainActivity.kt
@@ -13,7 +13,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.jhow.shopplist.data.icon.DictionaryLoader
-import com.jhow.shopplist.domain.icon.DefaultIconMatcher
+import com.jhow.shopplist.domain.icon.IconMatcher
 import com.jhow.shopplist.navigation.Routes
 import com.jhow.shopplist.presentation.caldavconfig.CalDavConfigRoute
 import com.jhow.shopplist.presentation.icon.IconResolver
@@ -40,7 +40,7 @@ class MainActivity : ComponentActivity() {
     lateinit var dictionaryLoader: DictionaryLoader
 
     @Inject
-    lateinit var defaultIconMatcher: DefaultIconMatcher
+    lateinit var iconMatcher: IconMatcher
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -91,7 +91,7 @@ class MainActivity : ComponentActivity() {
                 Log.w(TAG, "Failed to load icon dictionary, using generic icons", error)
                 return@launch
             }
-            val dictionaryChanged = defaultIconMatcher.updateDictionary(dictionary)
+            val dictionaryChanged = iconMatcher.updateDictionary(dictionary)
             if (dictionaryChanged) {
                 iconResolver.clearCache()
             }

--- a/app/src/main/java/com/jhow/shopplist/data/icon/DictionaryLoader.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/icon/DictionaryLoader.kt
@@ -15,7 +15,7 @@ interface DictionaryLoader {
     suspend fun load(): Map<String, IconBucket>
 }
 
-private val dictionaryJson = Json
+private val dictionaryJson = Json { ignoreUnknownKeys = true }
 
 class AssetDictionaryLoader(
     private val openAsset: suspend (String) -> InputStream

--- a/app/src/main/java/com/jhow/shopplist/data/icon/DictionaryLoader.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/icon/DictionaryLoader.kt
@@ -1,0 +1,69 @@
+package com.jhow.shopplist.data.icon
+
+import com.jhow.shopplist.domain.icon.IconBucket
+import java.io.InputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+interface DictionaryLoader {
+    suspend fun load(): Map<String, IconBucket>
+}
+
+private val dictionaryJson = Json
+
+class AssetDictionaryLoader(
+    private val openAsset: suspend (String) -> InputStream
+) : DictionaryLoader {
+
+    @Volatile
+    private var cachedDictionary: Map<String, IconBucket>? = null
+    private val loadMutex = Mutex()
+
+    override suspend fun load(): Map<String, IconBucket> {
+        cachedDictionary?.let { return it }
+
+        return withContext(Dispatchers.IO) {
+            loadMutex.withLock {
+                cachedDictionary?.let { return@withContext it }
+
+                val pt = openAsset("icons/dictionary-pt.json").use {
+                    parseDictionaryJson(it.bufferedReader().readText())
+                }
+                val en = openAsset("icons/dictionary-en.json").use {
+                    parseDictionaryJson(it.bufferedReader().readText())
+                }
+
+                val merged = pt + en
+                cachedDictionary = merged
+                merged
+            }
+        }
+    }
+}
+
+internal fun parseDictionaryJson(json: String): Map<String, IconBucket> {
+    val parsedElement = dictionaryJson.parseToJsonElement(json)
+    val dictionaryObject = parsedElement.asJsonObject()
+
+    return buildMap {
+        dictionaryObject.forEach { (key, value) ->
+            val bucketValue = value.jsonPrimitive.content.uppercase().replace("-", "_")
+            val bucket = runCatching { IconBucket.valueOf(bucketValue) }.getOrElse {
+                throw IllegalArgumentException("Unknown icon bucket '$bucketValue' for term '$key'", it)
+            }
+            put(key, bucket)
+        }
+    }
+}
+
+private fun JsonElement.asJsonObject() = runCatching {
+    jsonObject
+}.getOrElse {
+    throw IllegalArgumentException("Icon dictionary JSON must be an object", it)
+}

--- a/app/src/main/java/com/jhow/shopplist/di/IconModule.kt
+++ b/app/src/main/java/com/jhow/shopplist/di/IconModule.kt
@@ -1,14 +1,17 @@
 package com.jhow.shopplist.di
 
+import android.content.Context
+import com.jhow.shopplist.data.icon.AssetDictionaryLoader
+import com.jhow.shopplist.data.icon.DictionaryLoader
 import com.jhow.shopplist.domain.icon.DefaultIconMatcher
 import com.jhow.shopplist.domain.icon.DefaultTextNormalizer
-import com.jhow.shopplist.domain.icon.IconBucket
 import com.jhow.shopplist.domain.icon.IconMatcher
 import com.jhow.shopplist.domain.icon.TextNormalizer
 import com.jhow.shopplist.presentation.icon.IconResolver
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -22,27 +25,17 @@ object IconModule {
 
     @Provides
     @Singleton
-    fun provideIconMatcher(normalizer: TextNormalizer): IconMatcher {
-        val dictionary = mapOf(
-            "leite" to IconBucket.DAIRY,
-            "milk" to IconBucket.DAIRY,
-            "iogurte" to IconBucket.DAIRY,
-            "yogurt" to IconBucket.DAIRY,
-            "maçã" to IconBucket.FRUIT,
-            "maca" to IconBucket.FRUIT,
-            "apple" to IconBucket.FRUIT,
-            "banana" to IconBucket.FRUIT,
-            "pão" to IconBucket.BREAD,
-            "pao" to IconBucket.BREAD,
-            "bread" to IconBucket.BREAD,
-            "arroz" to IconBucket.PANTRY_CANNED,
-            "rice" to IconBucket.PANTRY_CANNED,
-            "feijão" to IconBucket.PANTRY_CANNED,
-            "feijao" to IconBucket.PANTRY_CANNED,
-            "beans" to IconBucket.PANTRY_CANNED
-        )
-        return DefaultIconMatcher(dictionary, normalizer)
-    }
+    fun provideDefaultIconMatcher(normalizer: TextNormalizer): DefaultIconMatcher =
+        DefaultIconMatcher(emptyMap(), normalizer)
+
+    @Provides
+    @Singleton
+    fun provideIconMatcher(matcher: DefaultIconMatcher): IconMatcher = matcher
+
+    @Provides
+    @Singleton
+    fun provideDictionaryLoader(@ApplicationContext context: Context): DictionaryLoader =
+        AssetDictionaryLoader { name -> context.assets.open(name) }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
@@ -2,8 +2,16 @@ package com.jhow.shopplist.domain.icon
 
 interface IconMatcher {
     fun match(itemName: String): IconBucket
+    fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean
 }
 
+/**
+ * Stateful singleton that delegates matching to a mutable dictionary reference.
+ *
+ * While the class holds mutable state, it is effectively a pure function for any
+ * given dictionary version: the same inputs always produce the same outputs until
+ * [updateDictionary] is called.
+ */
 class DefaultIconMatcher(
     dictionary: Map<String, IconBucket>,
     private val normalizer: TextNormalizer
@@ -12,7 +20,7 @@ class DefaultIconMatcher(
     @Volatile
     private var dictionaryRef: Map<String, IconBucket> = dictionary
 
-    fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean {
+    override fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean {
         if (dictionaryRef == newDictionary) {
             return false
         }

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
@@ -5,11 +5,23 @@ interface IconMatcher {
 }
 
 class DefaultIconMatcher(
-    private val dictionary: Map<String, IconBucket>,
+    dictionary: Map<String, IconBucket>,
     private val normalizer: TextNormalizer
 ) : IconMatcher {
+
+    @Volatile
+    private var dictionaryRef: Map<String, IconBucket> = dictionary
+
+    fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean {
+        if (dictionaryRef == newDictionary) {
+            return false
+        }
+        dictionaryRef = newDictionary
+        return true
+    }
+
     override fun match(itemName: String): IconBucket {
         val normalized = normalizer.normalize(itemName)
-        return dictionary[normalized] ?: IconBucket.GENERIC
+        return dictionaryRef[normalized] ?: IconBucket.GENERIC
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
@@ -1,15 +1,27 @@
 package com.jhow.shopplist.presentation.icon
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.jhow.shopplist.domain.icon.IconMatcher
 
 class IconResolver(private val matcher: IconMatcher) {
     private val cache = mutableMapOf<String, ImageVector>()
+    private var cacheVersionState by mutableIntStateOf(0)
+
+    val version: Int
+        get() = cacheVersionState
 
     fun resolveIcon(itemName: String): ImageVector {
         return cache.getOrPut(itemName) {
             val bucket = matcher.match(itemName)
             BucketIcons.forBucket(bucket)
         }
+    }
+
+    fun clearCache() {
+        cache.clear()
+        cacheVersionState += 1
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.jhow.shopplist.domain.icon.IconMatcher
 
 class IconResolver(private val matcher: IconMatcher) {
+    /** Main-thread only. */
     private val cache = mutableMapOf<String, ImageVector>()
     private var cacheVersionState by mutableIntStateOf(0)
 

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -722,10 +722,15 @@ private fun PendingItemRow(
         label = "pendingRowContentColor"
     )
 
+    val iconVersion = iconResolver.version
+    val leadingIcon = remember(item.name, iconVersion) {
+        iconResolver.resolveIcon(item.name)
+    }
+
     ShoppingItemRow(
         name = item.name,
         visuals = ShoppingItemRowVisuals(
-            leadingIcon = iconResolver.resolveIcon(item.name),
+            leadingIcon = leadingIcon,
             containerColor = containerColor,
             contentColor = contentColor
         ),
@@ -751,10 +756,15 @@ private fun PurchasedItemRow(
     iconResolver: IconResolver,
     modifier: Modifier = Modifier
 ) {
+    val iconVersion = iconResolver.version
+    val leadingIcon = remember(item.name, iconVersion) {
+        iconResolver.resolveIcon(item.name)
+    }
+
     ShoppingItemRow(
         name = item.name,
         visuals = ShoppingItemRowVisuals(
-            leadingIcon = iconResolver.resolveIcon(item.name),
+            leadingIcon = leadingIcon,
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
             contentColor = MaterialTheme.colorScheme.onSurface,
             textDecoration = TextDecoration.LineThrough,

--- a/app/src/test/java/com/jhow/shopplist/data/icon/DictionaryLoaderTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/data/icon/DictionaryLoaderTest.kt
@@ -53,7 +53,7 @@ class DictionaryLoaderTest {
     }
 
     @Test
-    fun `unknown bucket values are skipped`() = runTest {
+    fun `unknown bucket values throw illegal argument exception`() = runTest {
         val ptJson = """{"leite":"dairy","unknown":"not-a-bucket"}"""
         val enJson = """{}"""
 

--- a/app/src/test/java/com/jhow/shopplist/data/icon/DictionaryLoaderTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/data/icon/DictionaryLoaderTest.kt
@@ -1,0 +1,161 @@
+package com.jhow.shopplist.data.icon
+
+import com.jhow.shopplist.domain.icon.IconBucket
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.fail
+import org.junit.Test
+import kotlinx.serialization.SerializationException
+
+class DictionaryLoaderTest {
+
+    @Test
+    fun `loads and merges pt and en dictionaries end to end`() = runTest {
+        val ptJson = """{"leite":"dairy","pao":"bread"}"""
+        val enJson = """{"milk":"dairy","bread":"bread"}"""
+
+        val loader = AssetDictionaryLoader { name ->
+            when (name) {
+                "icons/dictionary-pt.json" -> ptJson.byteInputStream()
+                "icons/dictionary-en.json" -> enJson.byteInputStream()
+                else -> error("Unknown asset: $name")
+            }
+        }
+
+        val dictionary = loader.load()
+
+        assertEquals(IconBucket.DAIRY, dictionary["leite"])
+        assertEquals(IconBucket.BREAD, dictionary["pao"])
+        assertEquals(IconBucket.DAIRY, dictionary["milk"])
+        assertEquals(IconBucket.BREAD, dictionary["bread"])
+    }
+
+    @Test
+    fun `en terms override pt terms on collision`() = runTest {
+        val ptJson = """{"leite":"dairy"}"""
+        val enJson = """{"leite":"bread"}"""
+
+        val loader = AssetDictionaryLoader { name ->
+            when (name) {
+                "icons/dictionary-pt.json" -> ptJson.byteInputStream()
+                "icons/dictionary-en.json" -> enJson.byteInputStream()
+                else -> error("Unknown asset: $name")
+            }
+        }
+
+        val dictionary = loader.load()
+
+        assertEquals(IconBucket.BREAD, dictionary["leite"])
+    }
+
+    @Test
+    fun `unknown bucket values are skipped`() = runTest {
+        val ptJson = """{"leite":"dairy","unknown":"not-a-bucket"}"""
+        val enJson = """{}"""
+
+        val loader = AssetDictionaryLoader { name ->
+            when (name) {
+                "icons/dictionary-pt.json" -> ptJson.byteInputStream()
+                "icons/dictionary-en.json" -> enJson.byteInputStream()
+                else -> error("Unknown asset: $name")
+            }
+        }
+
+        try {
+            loader.load()
+            fail("Expected loader.load() to throw IllegalArgumentException")
+        } catch (_: IllegalArgumentException) {
+        }
+    }
+
+    @Test
+    fun `caches result so second load does not re read assets`() = runTest {
+        var openCount = 0
+        val ptJson = """{"leite":"dairy"}"""
+        val enJson = """{"milk":"dairy"}"""
+
+        val loader = AssetDictionaryLoader { name ->
+            openCount++
+            when (name) {
+                "icons/dictionary-pt.json" -> ptJson.byteInputStream()
+                "icons/dictionary-en.json" -> enJson.byteInputStream()
+                else -> error("Unknown asset: $name")
+            }
+        }
+
+        loader.load()
+        loader.load()
+
+        assertEquals(2, openCount)
+    }
+
+    @Test
+    fun `concurrent first loads only read each asset once`() = runTest {
+        var openCount = 0
+        val gate = CompletableDeferred<Unit>()
+        val ptJson = """{"leite":"dairy"}"""
+        val enJson = """{"milk":"dairy"}"""
+
+        val loader = AssetDictionaryLoader { name ->
+            gate.await()
+            openCount++
+            when (name) {
+                "icons/dictionary-pt.json" -> ptJson.byteInputStream()
+                "icons/dictionary-en.json" -> enJson.byteInputStream()
+                else -> error("Unknown asset: $name")
+            }
+        }
+
+        val deferredLoads = List(2) { async { loader.load() } }
+        gate.complete(Unit)
+
+        deferredLoads.awaitAll()
+
+        assertEquals(2, openCount)
+    }
+
+    @Test
+    fun `hyphenated bucket ids map to underscore enum names`() {
+        val ptJson = """{"arroz":"pantry-canned"}"""
+        val enJson = """{}"""
+        val result = parseDictionaryJson(ptJson) + parseDictionaryJson(enJson)
+        assertEquals(IconBucket.PANTRY_CANNED, result["arroz"])
+    }
+
+    @Test
+    fun `unicode escaped keys are decoded`() {
+        val cedilla = "\\" + "u00e7"
+        val tilde = "\\" + "u00e3"
+        val escapedJson = "{\"ma${cedilla}${tilde}\":\"fruit\",\"p${tilde}o\":\"bread\"}"
+
+        val result = parseDictionaryJson(escapedJson)
+
+        assertEquals(IconBucket.FRUIT, result["maçã"])
+        assertEquals(IconBucket.BREAD, result["pão"])
+    }
+
+    @Test
+    fun `malformed json throws serialization exception`() {
+        assertThrows(SerializationException::class.java) {
+            parseDictionaryJson("{\"leite\":")
+        }
+    }
+
+    @Test
+    fun `non object json throws illegal argument exception`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            parseDictionaryJson("[\"leite\"]")
+        }
+    }
+
+    @Test
+    fun `non primitive values throw illegal argument exception`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            parseDictionaryJson("{\"leite\":{\"bucket\":\"dairy\"}}")
+        }
+    }
+}

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
@@ -85,4 +85,20 @@ class IconMatcherTest {
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("Arroz"))
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("  Feijao  "))
     }
+
+    @Test
+    fun `updating dictionary changes match results`() {
+        val emptyMatcher = DefaultIconMatcher(emptyMap(), normalizer)
+        assertEquals(IconBucket.GENERIC, emptyMatcher.match("leite"))
+
+        assertEquals(true, emptyMatcher.updateDictionary(mapOf("leite" to IconBucket.DAIRY)))
+        assertEquals(IconBucket.DAIRY, emptyMatcher.match("leite"))
+    }
+
+    @Test
+    fun `updating dictionary with same contents reports unchanged`() {
+        val matcher = DefaultIconMatcher(dictionary, normalizer)
+
+        assertEquals(false, matcher.updateDictionary(dictionary.toMap()))
+    }
 }

--- a/app/src/test/java/com/jhow/shopplist/presentation/icon/IconResolverTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/icon/IconResolverTest.kt
@@ -36,4 +36,30 @@ class IconResolverTest {
         val icon2 = resolver.resolveIcon("leite")
         assertEquals(icon1, icon2)
     }
+
+    @Test
+    fun `clearing cache allows re resolution after dictionary update`() {
+        val emptyMatcher = DefaultIconMatcher(emptyMap(), DefaultTextNormalizer())
+        val dynamicResolver = IconResolver(emptyMatcher)
+
+        val genericIcon = dynamicResolver.resolveIcon("leite")
+        assertEquals(BucketIcons.forBucket(IconBucket.GENERIC), genericIcon)
+
+        emptyMatcher.updateDictionary(mapOf("leite" to IconBucket.DAIRY))
+        dynamicResolver.clearCache()
+
+        val dairyIcon = dynamicResolver.resolveIcon("leite")
+        assertEquals(BucketIcons.forBucket(IconBucket.DAIRY), dairyIcon)
+    }
+
+    @Test
+    fun `clearing cache increments resolver version`() {
+        val dynamicResolver = IconResolver(DefaultIconMatcher(emptyMap(), DefaultTextNormalizer()))
+
+        assertEquals(0, dynamicResolver.version)
+
+        dynamicResolver.clearCache()
+
+        assertEquals(1, dynamicResolver.version)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ materialIconsExtended = "1.7.8"
 navigationCompose = "2.9.8"
 okhttp = "4.10.0"
 room = "2.8.4"
+serializationJson = "1.9.0"
 turbine = "1.2.1"
 versionCatalogUpdate = "1.1.0"
 work = "2.11.2"
@@ -62,6 +63,7 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 


### PR DESCRIPTION
## Summary

Moves the hardcoded in-code icon dictionary from `IconModule` into JSON asset files under `app/src/main/assets/icons/`, loaded lazily off the main thread by a new `AssetDictionaryLoader`.

## What changed

### Data layer
- **New `data/icon/DictionaryLoader.kt`**
  - `DictionaryLoader` interface + `AssetDictionaryLoader` implementation
  - Reads `dictionary-pt.json` and `dictionary-en.json` via `kotlinx-serialization-json`
  - Merges with EN overriding PT on collision
  - Caches the result for the process lifetime
  - Single-flight first load via `Mutex`
  - Owns its own `withContext(Dispatchers.IO)` so callers can't accidentally block the main thread

### Domain layer
- **`DefaultIconMatcher.updateDictionary()`** now returns `Boolean` so callers know whether the dictionary actually changed (avoids unnecessary cache invalidation)

### Presentation layer
- **`IconResolver`** exposes an observable `version` backed by `mutableIntStateOf`; `clearCache()` increments it
- **`ShoppingListScreen`** rows use `remember(item.name, iconResolver.version)` so icons automatically recompose after the background dictionary load completes

### UI wiring
- **`MainActivity.loadIconDictionary()`** triggers the load on `onCreate`, catches `IOException` / `SerializationException` / `IllegalArgumentException`, and safely falls back to generic icons on any failure without crashing startup

### Build
- Added `kotlinx-serialization-json` dependency (`gradle/libs.versions.toml` + `app/build.gradle.kts`)

### Tests
- **`DictionaryLoaderTest`** — 8 tests covering load/merge, collision override, caching, concurrent single-flight, hyphen mapping, unicode-escaped keys, malformed JSON, and non-object JSON
- **`IconMatcherTest`** — added test for `updateDictionary()` change detection
- **`IconResolverTest`** — added test for cache invalidation incrementing version
- **Fixed pre-existing `ShoppingListItemIconTest`** — `ITEM_ICON` tag assertions need `useUnmergedTree=true` because `Icon` sits inside a mergeable `Row`

## Acceptance criteria

- [x] `dictionary-pt.json` and `dictionary-en.json` live under `app/src/main/assets/icons/`
- [x] JSON schema is a flat `{ "term": "bucket-id" }` map
- [x] `DictionaryLoader` reads both files off the main thread
- [x] Loaded dictionary is cached for the process; subsequent lookups never re-read assets
- [x] First list render is not blocked on dictionary load — a transient generic icon for one frame is acceptable
- [x] Hilt module provides `DictionaryLoader` and `IconMatcher` as singletons
- [x] Loader unit test confirms known PT and EN terms resolve to expected buckets end-to-end
- [x] All #41 acceptance criteria still hold (UI, behavior, tests)
- [x] `./gradlew lintDebug` and `./gradlew testDebugUnitTest` pass
- [x] Coverage stays ≥ 85%

## Out of scope (as per PRD)

- Build pipeline / Open Food Facts ingestion — the tooling directory is planned but not part of this slice
- Dictionary expansion beyond the existing ~15 terms — the JSON files carry the same vocabulary as before, only the data path changed

Fixes #42