### PR TITLE
feat(icon): full shallow-matcher cascade and normalization pipeline (#43)

### DIFF
--- a/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
@@ -7,7 +7,7 @@ interface IconMatcher {
 
 /**
  * Stateful singleton that resolves item names to icon buckets via a shallow cascade:
- * exact → alias → token-per-token → generic.
+ * exact → alias → token match (each token in order) → generic.
  *
  * Dictionary keys are normalized on ingestion so queries and keys use the same
  * representation. The cascade never uses stemming, fuzzy matching, or ML.
@@ -15,11 +15,13 @@ interface IconMatcher {
 class DefaultIconMatcher(
     dictionary: Map<String, IconBucket>,
     private val normalizer: TextNormalizer,
-    private val aliasMap: Map<String, IconBucket> = emptyMap()
+    aliasMap: Map<String, IconBucket> = emptyMap()
 ) : IconMatcher {
 
     @Volatile
     private var dictionaryRef: Map<String, IconBucket> = dictionary.normalizeKeys()
+
+    private val normalizedAliasMap: Map<String, IconBucket> = aliasMap.normalizeKeys()
 
     override fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean {
         val normalized = newDictionary.normalizeKeys()
@@ -33,9 +35,9 @@ class DefaultIconMatcher(
         if (normalized.isEmpty()) return IconBucket.GENERIC
 
         return dictionaryRef[normalized]
-            ?: aliasMap[normalized]
+            ?: normalizedAliasMap[normalized]
             ?: normalized.split(" ").filter { it.isNotBlank() }
-                .firstNotNullOfOrNull { token -> dictionaryRef[token] ?: aliasMap[token] }
+                .firstNotNullOfOrNull { token -> dictionaryRef[token] ?: normalizedAliasMap[token] }
             ?: IconBucket.GENERIC
     }
 

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/IconMatcher.kt
@@ -6,30 +6,39 @@ interface IconMatcher {
 }
 
 /**
- * Stateful singleton that delegates matching to a mutable dictionary reference.
+ * Stateful singleton that resolves item names to icon buckets via a shallow cascade:
+ * exact → alias → token-per-token → generic.
  *
- * While the class holds mutable state, it is effectively a pure function for any
- * given dictionary version: the same inputs always produce the same outputs until
- * [updateDictionary] is called.
+ * Dictionary keys are normalized on ingestion so queries and keys use the same
+ * representation. The cascade never uses stemming, fuzzy matching, or ML.
  */
 class DefaultIconMatcher(
     dictionary: Map<String, IconBucket>,
-    private val normalizer: TextNormalizer
+    private val normalizer: TextNormalizer,
+    private val aliasMap: Map<String, IconBucket> = emptyMap()
 ) : IconMatcher {
 
     @Volatile
-    private var dictionaryRef: Map<String, IconBucket> = dictionary
+    private var dictionaryRef: Map<String, IconBucket> = dictionary.normalizeKeys()
 
     override fun updateDictionary(newDictionary: Map<String, IconBucket>): Boolean {
-        if (dictionaryRef == newDictionary) {
-            return false
-        }
-        dictionaryRef = newDictionary
+        val normalized = newDictionary.normalizeKeys()
+        if (dictionaryRef == normalized) return false
+        dictionaryRef = normalized
         return true
     }
 
     override fun match(itemName: String): IconBucket {
         val normalized = normalizer.normalize(itemName)
-        return dictionaryRef[normalized] ?: IconBucket.GENERIC
+        if (normalized.isEmpty()) return IconBucket.GENERIC
+
+        return dictionaryRef[normalized]
+            ?: aliasMap[normalized]
+            ?: normalized.split(" ").filter { it.isNotBlank() }
+                .firstNotNullOfOrNull { token -> dictionaryRef[token] ?: aliasMap[token] }
+            ?: IconBucket.GENERIC
     }
+
+    private fun Map<String, IconBucket>.normalizeKeys(): Map<String, IconBucket> =
+        entries.associate { (k, v) -> normalizer.normalize(k) to v }
 }

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/TextNormalizer.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/TextNormalizer.kt
@@ -1,9 +1,37 @@
 package com.jhow.shopplist.domain.icon
 
+import java.text.Normalizer as JNormalizer
+
 interface TextNormalizer {
     fun normalize(text: String): String
 }
 
 class DefaultTextNormalizer : TextNormalizer {
-    override fun normalize(text: String): String = text.trim().lowercase()
+
+    private val quantityTokenRegex = Regex(
+        """^\d+(?:kg|g|mg|l|ml|un|unidades?|x)$""",
+        RegexOption.IGNORE_CASE
+    )
+
+    private val standaloneUnitWords = setOf("pacote", "pacotes", "pack", "packs", "unidade", "unidades")
+
+    private val stopwords = setOf("de", "do", "da", "dos", "das", "com", "the", "of", "and", "with")
+
+    override fun normalize(text: String): String {
+        val lowercased = text.trim().lowercase()
+        val diacriticsStripped = stripDiacritics(lowercased)
+        val tokens = diacriticsStripped.split(Regex("\\s+")).filter { it.isNotBlank() }
+        val filtered = tokens.filter { token ->
+            !isQuantityToken(token) && token !in stopwords
+        }
+        return filtered.joinToString(" ")
+    }
+
+    private fun stripDiacritics(s: String): String {
+        val nfd = JNormalizer.normalize(s, JNormalizer.Form.NFD)
+        return nfd.replace(Regex("\\p{InCombiningDiacriticalMarks}+"), "")
+    }
+
+    private fun isQuantityToken(token: String): Boolean =
+        token.matches(quantityTokenRegex) || token in standaloneUnitWords
 }

--- a/app/src/main/java/com/jhow/shopplist/domain/icon/TextNormalizer.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/icon/TextNormalizer.kt
@@ -9,11 +9,14 @@ interface TextNormalizer {
 class DefaultTextNormalizer : TextNormalizer {
 
     private val quantityTokenRegex = Regex(
-        """^\d+(?:kg|g|mg|l|ml|un|unidades?|x)$""",
+        """^\d+(?:[.,]\d+)?(?:kg|g|mg|l|ml|un|unidades?|x)?$""",
         RegexOption.IGNORE_CASE
     )
 
-    private val standaloneUnitWords = setOf("pacote", "pacotes", "pack", "packs", "unidade", "unidades")
+    private val standaloneUnitWords = setOf(
+        "kg", "g", "mg", "l", "ml",
+        "pacote", "pacotes", "pack", "packs", "unidade", "unidades"
+    )
 
     private val stopwords = setOf("de", "do", "da", "dos", "das", "com", "the", "of", "and", "with")
 

--- a/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/icon/IconResolver.kt
@@ -6,9 +6,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.jhow.shopplist.domain.icon.IconMatcher
 
-class IconResolver(private val matcher: IconMatcher) {
+private const val DEFAULT_CACHE_SIZE = 500
+private const val INITIAL_CAPACITY = 64
+private const val LOAD_FACTOR = 0.75f
+
+class IconResolver(
+    private val matcher: IconMatcher,
+    private val maxCacheSize: Int = DEFAULT_CACHE_SIZE
+) {
     /** Main-thread only. */
-    private val cache = mutableMapOf<String, ImageVector>()
+    private val cache: LinkedHashMap<String, ImageVector> =
+        object : LinkedHashMap<String, ImageVector>(INITIAL_CAPACITY, LOAD_FACTOR, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ImageVector>?) =
+                size > maxCacheSize
+        }
+
     private var cacheVersionState by mutableIntStateOf(0)
 
     val version: Int

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
@@ -10,22 +10,34 @@ class IconMatcherTest {
         "milk" to IconBucket.DAIRY,
         "iogurte" to IconBucket.DAIRY,
         "yogurt" to IconBucket.DAIRY,
-        "maçã" to IconBucket.FRUIT,
+        "queijo" to IconBucket.DAIRY,
+        "cheese" to IconBucket.DAIRY,
         "maca" to IconBucket.FRUIT,
         "apple" to IconBucket.FRUIT,
         "banana" to IconBucket.FRUIT,
-        "pão" to IconBucket.BREAD,
+        "laranja" to IconBucket.FRUIT,
+        "orange" to IconBucket.FRUIT,
+        "uva" to IconBucket.FRUIT,
         "pao" to IconBucket.BREAD,
         "bread" to IconBucket.BREAD,
+        "bisnaguinha" to IconBucket.BREAD,
         "arroz" to IconBucket.PANTRY_CANNED,
         "rice" to IconBucket.PANTRY_CANNED,
-        "feijão" to IconBucket.PANTRY_CANNED,
         "feijao" to IconBucket.PANTRY_CANNED,
-        "beans" to IconBucket.PANTRY_CANNED
+        "beans" to IconBucket.PANTRY_CANNED,
+        "macarrao" to IconBucket.PANTRY_CANNED,
+        "pasta" to IconBucket.PANTRY_CANNED,
+    )
+
+    private val aliasMap = mapOf(
+        "leites" to IconBucket.DAIRY,
+        "bananas" to IconBucket.FRUIT,
     )
 
     private val normalizer = DefaultTextNormalizer()
-    private val matcher = DefaultIconMatcher(dictionary, normalizer)
+    private val matcher = DefaultIconMatcher(dictionary, normalizer, aliasMap)
+
+    // ── Exact match ───────────────────────────────────────────────────────────
 
     @Test
     fun `exact match returns corresponding bucket`() {
@@ -33,14 +45,208 @@ class IconMatcherTest {
     }
 
     @Test
-    fun `exact match with different casing returns bucket`() {
+    fun `exact match is case-insensitive`() {
         assertEquals(IconBucket.DAIRY, matcher.match("Leite"))
     }
 
     @Test
-    fun `exact match with whitespace returns bucket`() {
+    fun `exact match trims whitespace`() {
         assertEquals(IconBucket.DAIRY, matcher.match("  leite  "))
     }
+
+    @Test
+    fun `exact match after diacritic normalization`() {
+        // maçã normalizes to maca, which is in the dictionary
+        assertEquals(IconBucket.FRUIT, matcher.match("maçã"))
+    }
+
+    @Test
+    fun `exact match after diacritic normalization pao`() {
+        assertEquals(IconBucket.BREAD, matcher.match("pão"))
+    }
+
+    @Test
+    fun `exact match after diacritic normalization feijao`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijão"))
+    }
+
+    // ── Alias match ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `plural form resolved via alias map`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("leites"))
+    }
+
+    @Test
+    fun `plural form resolved via alias map fruit`() {
+        assertEquals(IconBucket.FRUIT, matcher.match("bananas"))
+    }
+
+    // ── Token-head match ──────────────────────────────────────────────────────
+
+    @Test
+    fun `multi-word item resolved via head token`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("leite integral"))
+    }
+
+    @Test
+    fun `multi-word item with diacritics resolved via head token`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijão preto"))
+    }
+
+    @Test
+    fun `leading quantity stripped before token match`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("2kg arroz"))
+    }
+
+    @Test
+    fun `leading quantity and adjective stripped for token match`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("2kg arroz integral"))
+    }
+
+    @Test
+    fun `2kg arroz integral resolves same bucket as bare arroz`() {
+        assertEquals(matcher.match("arroz"), matcher.match("2kg arroz integral"))
+    }
+
+    @Test
+    fun `trailing quantity stripped before token match`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijao 500g"))
+    }
+
+    @Test
+    fun `500ml leite resolves same bucket as bare leite`() {
+        assertEquals(matcher.match("leite"), matcher.match("500ml leite"))
+    }
+
+    @Test
+    fun `leite integral resolved via head token`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("leite integral"))
+    }
+
+    @Test
+    fun `leite desnatado resolved via head token`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("leite desnatado"))
+    }
+
+    @Test
+    fun `arroz branco resolved via head token`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("arroz branco"))
+    }
+
+    @Test
+    fun `arroz integral resolved via head token`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("arroz integral"))
+    }
+
+    @Test
+    fun `feijao carioca resolved via head token`() {
+        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijao carioca"))
+    }
+
+    @Test
+    fun `banana nanica resolved via head token`() {
+        assertEquals(IconBucket.FRUIT, matcher.match("banana nanica"))
+    }
+
+    @Test
+    fun `banana prata resolved via head token`() {
+        assertEquals(IconBucket.FRUIT, matcher.match("banana prata"))
+    }
+
+    @Test
+    fun `iogurte grego resolved via head token`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("iogurte grego"))
+    }
+
+    @Test
+    fun `queijo mussarela resolved via head token`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("queijo mussarela"))
+    }
+
+    @Test
+    fun `pao de queijo resolved via head token after stopword removal`() {
+        // "pao de queijo" → stopword "de" removed → "pao queijo" → token "pao" → BREAD
+        assertEquals(IconBucket.BREAD, matcher.match("pão de queijo"))
+    }
+
+    @Test
+    fun `iogurte de morango resolved via head token after stopword removal`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("iogurte de morango"))
+    }
+
+    @Test
+    fun `leite do campo resolved via head token after stopword removal`() {
+        assertEquals(IconBucket.DAIRY, matcher.match("leite do campo"))
+    }
+
+    @Test
+    fun `maca verde resolved via head token`() {
+        assertEquals(IconBucket.FRUIT, matcher.match("maçã verde"))
+    }
+
+    // ── Mixed-language inputs ─────────────────────────────────────────────────
+
+    @Test
+    fun `milk powder resolved via head token`() {
+        // "milk powder" → token "milk" → DAIRY
+        assertEquals(IconBucket.DAIRY, matcher.match("milk powder"))
+    }
+
+    @Test
+    fun `apple juice resolved via head token`() {
+        assertEquals(IconBucket.FRUIT, matcher.match("apple juice"))
+    }
+
+    @Test
+    fun `shampoo Pantene resolves to generic when not in dictionary`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("shampoo Pantene"))
+    }
+
+    @Test
+    fun `racao Whiskas resolves to generic when not in dictionary`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("ração Whiskas"))
+    }
+
+    @Test
+    fun `whey protein resolves to generic when not in dictionary`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("whey protein"))
+    }
+
+    // ── Near-miss and ambiguity cases ─────────────────────────────────────────
+
+    @Test
+    fun `pimenta alone resolves to generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("pimenta"))
+    }
+
+    @Test
+    fun `pimenta do reino resolves to generic after stopword removal`() {
+        // "pimenta do reino" → "pimenta reino" → token "pimenta" not in dict → GENERIC
+        assertEquals(IconBucket.GENERIC, matcher.match("pimenta do reino"))
+    }
+
+    @Test
+    fun `sal resolves to generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("sal"))
+    }
+
+    @Test
+    fun `aipim resolves to generic (regional, not in slice-1 dict)`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("aipim"))
+    }
+
+    @Test
+    fun `macaxeira resolves to generic (regional, not in slice-1 dict)`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("macaxeira"))
+    }
+
+    @Test
+    fun `polenta resolves to generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("polenta"))
+    }
+
+    // ── GENERIC fallback cases ────────────────────────────────────────────────
 
     @Test
     fun `unknown term returns generic`() {
@@ -48,13 +254,48 @@ class IconMatcherTest {
     }
 
     @Test
-    fun `unknown english term returns generic`() {
-        assertEquals(IconBucket.GENERIC, matcher.match("screwdriver"))
+    fun `hardware item returns generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("cabo USB"))
+    }
+
+    @Test
+    fun `clothing item returns generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("camisa"))
     }
 
     @Test
     fun `empty string returns generic`() {
         assertEquals(IconBucket.GENERIC, matcher.match(""))
+    }
+
+    @Test
+    fun `whitespace-only string returns generic`() {
+        assertEquals(IconBucket.GENERIC, matcher.match("   "))
+    }
+
+    // ── Dictionary update ─────────────────────────────────────────────────────
+
+    @Test
+    fun `updating dictionary changes match results`() {
+        val emptyMatcher = DefaultIconMatcher(emptyMap(), normalizer)
+        assertEquals(IconBucket.GENERIC, emptyMatcher.match("leite"))
+
+        assertEquals(true, emptyMatcher.updateDictionary(mapOf("leite" to IconBucket.DAIRY)))
+        assertEquals(IconBucket.DAIRY, emptyMatcher.match("leite"))
+    }
+
+    @Test
+    fun `updating dictionary with same contents reports unchanged`() {
+        val sameMatcher = DefaultIconMatcher(dictionary, normalizer)
+        assertEquals(false, sameMatcher.updateDictionary(dictionary.toMap()))
+    }
+
+    @Test
+    fun `updating dictionary with accented keys normalizes them`() {
+        val m = DefaultIconMatcher(emptyMap(), normalizer)
+        m.updateDictionary(mapOf("maçã" to IconBucket.FRUIT))
+        // query without accent resolves correctly after normalization
+        assertEquals(IconBucket.FRUIT, m.match("maca"))
     }
 
     @Test
@@ -78,27 +319,5 @@ class IconMatcherTest {
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijão"))
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijao"))
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("beans"))
-    }
-
-    @Test
-    fun `mixed case pantry term resolves correctly`() {
-        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("Arroz"))
-        assertEquals(IconBucket.PANTRY_CANNED, matcher.match("  Feijao  "))
-    }
-
-    @Test
-    fun `updating dictionary changes match results`() {
-        val emptyMatcher = DefaultIconMatcher(emptyMap(), normalizer)
-        assertEquals(IconBucket.GENERIC, emptyMatcher.match("leite"))
-
-        assertEquals(true, emptyMatcher.updateDictionary(mapOf("leite" to IconBucket.DAIRY)))
-        assertEquals(IconBucket.DAIRY, emptyMatcher.match("leite"))
-    }
-
-    @Test
-    fun `updating dictionary with same contents reports unchanged`() {
-        val matcher = DefaultIconMatcher(dictionary, normalizer)
-
-        assertEquals(false, matcher.updateDictionary(dictionary.toMap()))
     }
 }

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/IconMatcherTest.kt
@@ -85,12 +85,12 @@ class IconMatcherTest {
     // ── Token-head match ──────────────────────────────────────────────────────
 
     @Test
-    fun `multi-word item resolved via head token`() {
+    fun `multi-word item resolved via token match`() {
         assertEquals(IconBucket.DAIRY, matcher.match("leite integral"))
     }
 
     @Test
-    fun `multi-word item with diacritics resolved via head token`() {
+    fun `multi-word item with diacritics resolved via token match`() {
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijão preto"))
     }
 
@@ -120,81 +120,87 @@ class IconMatcherTest {
     }
 
     @Test
-    fun `leite integral resolved via head token`() {
+    fun `leite integral resolved via token match`() {
         assertEquals(IconBucket.DAIRY, matcher.match("leite integral"))
     }
 
     @Test
-    fun `leite desnatado resolved via head token`() {
+    fun `leite desnatado resolved via token match`() {
         assertEquals(IconBucket.DAIRY, matcher.match("leite desnatado"))
     }
 
     @Test
-    fun `arroz branco resolved via head token`() {
+    fun `arroz branco resolved via token match`() {
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("arroz branco"))
     }
 
     @Test
-    fun `arroz integral resolved via head token`() {
+    fun `arroz integral resolved via token match`() {
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("arroz integral"))
     }
 
     @Test
-    fun `feijao carioca resolved via head token`() {
+    fun `feijao carioca resolved via token match`() {
         assertEquals(IconBucket.PANTRY_CANNED, matcher.match("feijao carioca"))
     }
 
     @Test
-    fun `banana nanica resolved via head token`() {
+    fun `banana nanica resolved via token match`() {
         assertEquals(IconBucket.FRUIT, matcher.match("banana nanica"))
     }
 
     @Test
-    fun `banana prata resolved via head token`() {
+    fun `banana prata resolved via token match`() {
         assertEquals(IconBucket.FRUIT, matcher.match("banana prata"))
     }
 
     @Test
-    fun `iogurte grego resolved via head token`() {
+    fun `iogurte grego resolved via token match`() {
         assertEquals(IconBucket.DAIRY, matcher.match("iogurte grego"))
     }
 
     @Test
-    fun `queijo mussarela resolved via head token`() {
+    fun `queijo mussarela resolved via token match`() {
         assertEquals(IconBucket.DAIRY, matcher.match("queijo mussarela"))
     }
 
     @Test
-    fun `pao de queijo resolved via head token after stopword removal`() {
+    fun `pao de queijo resolved via token match after stopword removal`() {
         // "pao de queijo" → stopword "de" removed → "pao queijo" → token "pao" → BREAD
         assertEquals(IconBucket.BREAD, matcher.match("pão de queijo"))
     }
 
     @Test
-    fun `iogurte de morango resolved via head token after stopword removal`() {
+    fun `iogurte de morango resolved via token match after stopword removal`() {
         assertEquals(IconBucket.DAIRY, matcher.match("iogurte de morango"))
     }
 
     @Test
-    fun `leite do campo resolved via head token after stopword removal`() {
+    fun `leite do campo resolved via token match after stopword removal`() {
         assertEquals(IconBucket.DAIRY, matcher.match("leite do campo"))
     }
 
     @Test
-    fun `maca verde resolved via head token`() {
+    fun `maca verde resolved via token match`() {
         assertEquals(IconBucket.FRUIT, matcher.match("maçã verde"))
+    }
+
+    @Test
+    fun `non-head token match — first token misses, later token hits`() {
+        // "embalagem leite" → "embalagem" not in dict, "leite" is → DAIRY
+        assertEquals(IconBucket.DAIRY, matcher.match("embalagem leite"))
     }
 
     // ── Mixed-language inputs ─────────────────────────────────────────────────
 
     @Test
-    fun `milk powder resolved via head token`() {
+    fun `milk powder resolved via token match`() {
         // "milk powder" → token "milk" → DAIRY
         assertEquals(IconBucket.DAIRY, matcher.match("milk powder"))
     }
 
     @Test
-    fun `apple juice resolved via head token`() {
+    fun `apple juice resolved via token match`() {
         assertEquals(IconBucket.FRUIT, matcher.match("apple juice"))
     }
 
@@ -294,8 +300,14 @@ class IconMatcherTest {
     fun `updating dictionary with accented keys normalizes them`() {
         val m = DefaultIconMatcher(emptyMap(), normalizer)
         m.updateDictionary(mapOf("maçã" to IconBucket.FRUIT))
-        // query without accent resolves correctly after normalization
         assertEquals(IconBucket.FRUIT, m.match("maca"))
+    }
+
+    @Test
+    fun `alias map keys are normalized at construction so accented aliases work`() {
+        // "maçãs" key → normalized to "macas"; query "maçãs" also normalizes to "macas"
+        val m = DefaultIconMatcher(emptyMap(), normalizer, mapOf("maçãs" to IconBucket.FRUIT))
+        assertEquals(IconBucket.FRUIT, m.match("maçãs"))
     }
 
     @Test

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/TextNormalizerTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/TextNormalizerTest.kt
@@ -178,6 +178,29 @@ class TextNormalizerTest {
         assertEquals("arroz feijao", normalizer.normalize("2kg arroz com feijao"))
     }
 
+    // ── Decimal and space-separated quantity formats ───────────────────────────
+
+    @Test
+    fun `strips decimal dot quantity`() {
+        assertEquals("arroz", normalizer.normalize("1.5kg arroz"))
+    }
+
+    @Test
+    fun `strips decimal comma quantity (PT-BR style)`() {
+        assertEquals("leite", normalizer.normalize("1,5l leite"))
+    }
+
+    @Test
+    fun `strips space-separated number and unit`() {
+        // "500 ml leite" → "500" is a bare number token, "ml" is a standalone unit
+        assertEquals("leite", normalizer.normalize("500 ml leite"))
+    }
+
+    @Test
+    fun `strips standalone unit ml`() {
+        assertEquals("leite", normalizer.normalize("leite ml"))
+    }
+
     // ── Space collapsing ──────────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/jhow/shopplist/domain/icon/TextNormalizerTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/domain/icon/TextNormalizerTest.kt
@@ -7,6 +7,8 @@ class TextNormalizerTest {
 
     private val normalizer = DefaultTextNormalizer()
 
+    // ── Trim + lowercase ──────────────────────────────────────────────────────
+
     @Test
     fun `lowercases simple term`() {
         assertEquals("leite", normalizer.normalize("Leite"))
@@ -43,17 +45,143 @@ class TextNormalizerTest {
     }
 
     @Test
-    fun `internal whitespace is preserved`() {
-        assertEquals("pao de queijo", normalizer.normalize("Pao de Queijo"))
-    }
-
-    @Test
     fun `single character is lowercased`() {
         assertEquals("a", normalizer.normalize("A"))
     }
 
+    // ── NFD diacritic stripping ───────────────────────────────────────────────
+
     @Test
-    fun `numeric characters are preserved`() {
-        assertEquals("2kg arroz", normalizer.normalize("2kg Arroz"))
+    fun `strips cedilla from maca`() {
+        assertEquals("maca", normalizer.normalize("maçã"))
+    }
+
+    @Test
+    fun `strips acute accent from cafe`() {
+        assertEquals("cafe", normalizer.normalize("café"))
+    }
+
+    @Test
+    fun `strips tilde from feijao`() {
+        assertEquals("feijao", normalizer.normalize("feijão"))
+    }
+
+    @Test
+    fun `strips circumflex from pao`() {
+        assertEquals("pao", normalizer.normalize("pão"))
+    }
+
+    @Test
+    fun `strips accent from acucar`() {
+        assertEquals("acucar", normalizer.normalize("açúcar"))
+    }
+
+    @Test
+    fun `term without diacritics is unchanged`() {
+        assertEquals("cenoura", normalizer.normalize("cenoura"))
+    }
+
+    @Test
+    fun `mixed diacritics and plain chars stripped correctly`() {
+        assertEquals("maca verde", normalizer.normalize("maçã verde"))
+    }
+
+    // ── Quantity and unit token removal ───────────────────────────────────────
+
+    @Test
+    fun `strips leading quantity kg`() {
+        assertEquals("arroz", normalizer.normalize("2kg arroz"))
+    }
+
+    @Test
+    fun `strips leading quantity ml`() {
+        assertEquals("leite", normalizer.normalize("500ml leite"))
+    }
+
+    @Test
+    fun `strips trailing quantity kg`() {
+        assertEquals("arroz", normalizer.normalize("arroz 2kg"))
+    }
+
+    @Test
+    fun `strips quantity g`() {
+        assertEquals("queijo", normalizer.normalize("100g queijo"))
+    }
+
+    @Test
+    fun `strips multiplier x`() {
+        assertEquals("banana", normalizer.normalize("2x banana"))
+    }
+
+    @Test
+    fun `strips standalone pacote`() {
+        assertEquals("macarrao", normalizer.normalize("pacote macarrao"))
+    }
+
+    @Test
+    fun `strips standalone pack`() {
+        assertEquals("chips", normalizer.normalize("pack chips"))
+    }
+
+    @Test
+    fun `strips quantity from multi-word item leaving rest intact`() {
+        assertEquals("arroz integral", normalizer.normalize("2kg arroz integral"))
+    }
+
+    @Test
+    fun `2kg arroz integral and bare arroz normalize to same prefix`() {
+        val withQty = normalizer.normalize("2kg arroz integral")
+        val bare = normalizer.normalize("arroz")
+        assertEquals("arroz", bare)
+        assertEquals(true, withQty.startsWith(bare))
+    }
+
+    // ── Stopword removal ──────────────────────────────────────────────────────
+
+    @Test
+    fun `removes PT preposition do`() {
+        assertEquals("leite campo", normalizer.normalize("leite do campo"))
+    }
+
+    @Test
+    fun `removes PT preposition de`() {
+        assertEquals("iogurte morango", normalizer.normalize("iogurte de morango"))
+    }
+
+    @Test
+    fun `removes PT preposition da`() {
+        assertEquals("pao vovo", normalizer.normalize("pao da vovo"))
+    }
+
+    @Test
+    fun `removes PT conjunction com`() {
+        assertEquals("feijao arroz", normalizer.normalize("feijao com arroz"))
+    }
+
+    @Test
+    fun `removes EN preposition of`() {
+        assertEquals("bread life", normalizer.normalize("bread of life"))
+    }
+
+    @Test
+    fun `removes EN preposition the`() {
+        assertEquals("best cheese", normalizer.normalize("the best cheese"))
+    }
+
+    @Test
+    fun `removes stopwords and strips diacritics combined`() {
+        assertEquals("pao queijo", normalizer.normalize("pão de queijo"))
+    }
+
+    @Test
+    fun `removes quantity and stopword combined`() {
+        assertEquals("arroz feijao", normalizer.normalize("2kg arroz com feijao"))
+    }
+
+    // ── Space collapsing ──────────────────────────────────────────────────────
+
+    @Test
+    fun `collapses multiple internal spaces`() {
+        assertEquals("arroz branco", normalizer.normalize("arroz  branco"))
     }
 }

--- a/app/src/test/java/com/jhow/shopplist/presentation/icon/IconResolverTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/icon/IconResolverTest.kt
@@ -1,11 +1,9 @@
 package com.jhow.shopplist.presentation.icon
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.ShoppingBasket
-import androidx.compose.material.icons.rounded.WaterDrop
 import com.jhow.shopplist.domain.icon.DefaultIconMatcher
 import com.jhow.shopplist.domain.icon.DefaultTextNormalizer
 import com.jhow.shopplist.domain.icon.IconBucket
+import com.jhow.shopplist.domain.icon.IconMatcher
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -13,7 +11,8 @@ class IconResolverTest {
 
     private val dictionary = mapOf(
         "leite" to IconBucket.DAIRY,
-        "milk" to IconBucket.DAIRY
+        "milk" to IconBucket.DAIRY,
+        "arroz" to IconBucket.PANTRY_CANNED,
     )
     private val matcher = DefaultIconMatcher(dictionary, DefaultTextNormalizer())
     private val resolver = IconResolver(matcher)
@@ -61,5 +60,56 @@ class IconResolverTest {
         dynamicResolver.clearCache()
 
         assertEquals(1, dynamicResolver.version)
+    }
+
+    @Test
+    fun `lru cache does not call matcher again for cached entry`() {
+        val counting = CountingMatcher(matcher)
+        val r = IconResolver(counting)
+
+        r.resolveIcon("leite")
+        r.resolveIcon("leite")
+
+        assertEquals("cache hit should not call matcher again", 1, counting.callCount)
+    }
+
+    @Test
+    fun `lru evicts least recently used entry when capacity exceeded`() {
+        val counting = CountingMatcher(matcher)
+        val r = IconResolver(counting, maxCacheSize = 2)
+
+        r.resolveIcon("leite")   // miss; count=1; cache: [leite]
+        r.resolveIcon("milk")    // miss; count=2; cache order: leite(LRU) < milk(MRU)
+        assertEquals(2, counting.callCount)
+
+        // Promote leite to MRU so milk becomes the new LRU
+        r.resolveIcon("leite")   // hit; order: milk(LRU) < leite(MRU)
+        assertEquals("cache hit should not call matcher", 2, counting.callCount)
+
+        // Adding arroz evicts milk (LRU), not leite (MRU)
+        r.resolveIcon("arroz")   // miss; count=3; evicts milk; cache: [leite, arroz]
+        assertEquals(3, counting.callCount)
+
+        // leite survived the eviction (it was MRU before arroz was added)
+        r.resolveIcon("leite")   // hit; count stays 3
+        assertEquals("leite was MRU and should still be cached", 3, counting.callCount)
+
+        // milk was evicted and must be re-resolved
+        r.resolveIcon("milk")    // miss; count=4
+        assertEquals("milk was evicted and requires a new matcher call", 4, counting.callCount)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private class CountingMatcher(
+        private val delegate: IconMatcher,
+        var callCount: Int = 0
+    ) : IconMatcher {
+        override fun match(itemName: String): IconBucket {
+            callCount++
+            return delegate.match(itemName)
+        }
+        override fun updateDictionary(newDictionary: Map<String, IconBucket>) =
+            delegate.updateDictionary(newDictionary)
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #43 — full shallow-matcher cascade and normalization pipeline.

- **TextNormalizer** now runs the complete pipeline: NFD + diacritic strip → quantity/unit token removal → per-language stopword removal → space collapse
- **IconMatcher** runs the full cascade: exact → alias map → token-per-token → generic; dictionary keys are normalized at ingestion so accented JSON keys and queries always meet in the same form
- **IconResolver** replaces the unbounded `mutableMapOf` with a `LinkedHashMap` LRU cache (default 500 entries, configurable for tests)

## Changes

| File | What changed |
|---|---|
| `domain/icon/TextNormalizer.kt` | Full pipeline replacing `trim().lowercase()` |
| `domain/icon/IconMatcher.kt` | Cascade + alias map param + key normalization on ingestion |
| `presentation/icon/IconResolver.kt` | LRU eviction via `LinkedHashMap(accessOrder=true)` |
| `TextNormalizerTest.kt` | 10 → 33 test cases |
| `IconMatcherTest.kt` | 10 → 50 test cases |
| `IconResolverTest.kt` | +2 LRU tests with `CountingMatcher` helper |

## Acceptance criteria checklist

- [x] `TextNormalizer` strips quantities and unit tokens (`2kg`, `500g`, `1l`, `500ml`, `2x`, `pacote`, `pack`)
- [x] `TextNormalizer` strips diacritics via NFD (`maçã` → `maca`, `café` → `cafe`)
- [x] `TextNormalizer` removes per-language stopwords (`de`, `do`, `da`, `com`, `the`, `of`, …)
- [x] `IconMatcher` cascade order: exact → alias → token-per-token → generic
- [x] No stemming, no fuzzy/Levenshtein, no embeddings, no ML
- [x] `IconResolver` memoizes in a per-process LRU cache keyed by raw item name
- [x] Normalizer test corpus ≥ 30 cases (33)
- [x] Matcher test corpus ≥ 50 PT-BR + EN cases with ambiguity cases (50)
- [x] `"2kg arroz integral"` and `"arroz"` resolve to the same bucket
- [x] Mixed-language inputs (`"shampoo Pantene"`, `"ração Whiskas"`) resolve without error
- [x] All #42 acceptance criteria still hold
- [x] `./gradlew lintDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] Coverage stays ≥ 85%

## Test plan

- [x] `./gradlew testDebugUnitTest` — all unit tests green
- [x] `./gradlew lintDebug` — lint + detekt clean

Closes #43