### PR TITLE
feat: switch shopping list to one-tap purchase mode

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -55,13 +56,12 @@ class ShoppingListScreenTest {
     }
 
     @Test
-    fun selectingPendingItemShowsFabAndMovesItemToPurchased() {
+    fun tappingPendingItemMovesItToPurchasedImmediately() {
         assertTrue(
             composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-apples")).fetchSemanticsNodes().isNotEmpty()
         )
 
         composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performClick()
-        composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB).performClick()
         composeRule.waitForIdle()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
@@ -72,7 +72,7 @@ class ShoppingListScreenTest {
             composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-apples")).fetchSemanticsNodes().isNotEmpty()
         )
         assertFalse(
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB).fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.PURCHASE_SELECTED_BUTTON).fetchSemanticsNodes().isNotEmpty()
         )
     }
 
@@ -106,20 +106,74 @@ class ShoppingListScreenTest {
     }
 
     @Test
-    fun bulkActionFabFloatsAboveExpandedInputComposer() {
-        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performClick()
-        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("co")
+    fun longPressingPendingItemEntersSelectionModeWithContextualActions() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performTouchInput {
+            longClick()
+        }
         composeRule.waitForIdle()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB).fetchSemanticsNodes().isNotEmpty() &&
-                composeRule.onAllNodesWithTag(ShoppingListTestTags.SUGGESTION_LIST).fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.PURCHASE_SELECTED_BUTTON).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_SELECTED_BUTTON).fetchSemanticsNodes().isNotEmpty()
         }
 
-        val fabBottom = composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB).fetchSemanticsNode().boundsInRoot.bottom
-        val suggestionTop = composeRule.onNodeWithTag(ShoppingListTestTags.SUGGESTION_LIST).fetchSemanticsNode().boundsInRoot.top
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.EXIT_SELECTION_BUTTON).fetchSemanticsNodes().isNotEmpty()
+        )
+    }
 
-        assertTrue(fabBottom <= suggestionTop)
+    @Test
+    fun tappingPendingItemWhileSelectionModeActiveTogglesSelectionInsteadOfPurchasing() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performTouchInput {
+            longClick()
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-bread")).performClick()
+        composeRule.waitForIdle()
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-bread")).fetchSemanticsNodes().isNotEmpty()
+        )
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-bread")).fetchSemanticsNodes().isEmpty()
+        )
+    }
+
+    @Test
+    fun purchaseSelectedActionMarksAllSelectedItemsPurchased() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performTouchInput {
+            longClick()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-bread")).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASE_SELECTED_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-apples")).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-bread")).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun deleteSelectedActionRemovesAllSelectedItems() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performTouchInput {
+            longClick()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-bread")).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.DELETE_SELECTED_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-apples")).fetchSemanticsNodes().isEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-bread")).fetchSemanticsNodes().isEmpty()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jhow.shopplist.domain.icon.IconBucket
@@ -160,5 +161,26 @@ class ShoppingListTopBarTest {
         composeRule.onNodeWithTag(ShoppingListTestTags.SYNC_BADGE_SPINNER).assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Sync now").assertIsDisplayed()
         composeRule.onAllNodesWithTag(ShoppingListTestTags.MANUAL_SYNC_LOADER).assertCountEquals(0)
+    }
+
+    @Test
+    fun selectionMode_topBarShowsContextualActions() {
+        composeRule.setContent {
+            ShoppingListScreen(
+                uiState = ShoppingListUiState(
+                    selectedIds = setOf("item-1", "item-2"),
+                    isSelectionMode = true
+                ),
+                snackbarHostState = SnackbarHostState(),
+                iconResolver = fakeIconResolver
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.EXIT_SELECTION_BUTTON).assertIsDisplayed()
+        composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASE_SELECTED_BUTTON).assertIsDisplayed()
+        composeRule.onNodeWithTag(ShoppingListTestTags.DELETE_SELECTED_BUTTON).assertIsDisplayed()
+        composeRule.onNodeWithText("2").assertIsDisplayed()
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.SYNC_SETTINGS_BUTTON).assertCountEquals(0)
     }
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/SelectionController.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/SelectionController.kt
@@ -34,4 +34,14 @@ class SelectionController @Inject constructor() {
         mutableSelected.value = emptySet()
         mutableIsActive.value = false
     }
+
+    internal fun retainOnly(validItemIds: Set<String>) {
+        if (!mutableIsActive.value) return
+
+        val retainedSelection = mutableSelected.value.intersect(validItemIds)
+        if (retainedSelection == mutableSelected.value) return
+
+        mutableSelected.value = retainedSelection
+        mutableIsActive.value = retainedSelection.isNotEmpty()
+    }
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/SelectionController.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/SelectionController.kt
@@ -1,0 +1,37 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SelectionController @Inject constructor() {
+    private val mutableSelected = MutableStateFlow(emptySet<String>())
+    private val mutableIsActive = MutableStateFlow(false)
+
+    val selected: StateFlow<Set<String>> = mutableSelected.asStateFlow()
+    val isActive: StateFlow<Boolean> = mutableIsActive.asStateFlow()
+
+    fun enter(itemId: String) {
+        if (mutableIsActive.value) return
+
+        mutableSelected.value = setOf(itemId)
+        mutableIsActive.value = true
+    }
+
+    fun toggle(itemId: String) {
+        if (!mutableIsActive.value) return
+
+        val updatedSelection = mutableSelected.value.let { currentSelection ->
+            if (itemId in currentSelection) currentSelection - itemId else currentSelection + itemId
+        }
+
+        mutableSelected.value = updatedSelection
+        mutableIsActive.value = updatedSelection.isNotEmpty()
+    }
+
+    fun exit() {
+        mutableSelected.value = emptySet()
+        mutableIsActive.value = false
+    }
+}

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -2,12 +2,11 @@ package com.jhow.shopplist.presentation.shoppinglist
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +25,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.foundation.text.KeyboardActions
@@ -34,13 +32,14 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AddTask
 import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.ShoppingBag
 import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -96,8 +95,11 @@ class ShoppingListInputCallbacks(
 
 class ShoppingListItemCallbacks(
     val onPendingItemClick: (String) -> Unit = {},
+    val onPendingItemLongPress: (String) -> Unit = {},
     val onPurchasedItemClick: (String) -> Unit = {},
     val onPurchaseSelectedItems: () -> Unit = {},
+    val onDeleteSelectedItems: () -> Unit = {},
+    val onSelectionModeExited: () -> Unit = {},
     val onDeleteItemRequested: (ShoppingItem) -> Unit = {},
     val onDeleteItemDismissed: () -> Unit = {},
     val onDeleteItemConfirmed: () -> Unit = {}
@@ -116,8 +118,15 @@ private data class ShoppingItemRowVisuals(
     val rowAlpha: Float = 1f
 )
 
+private data class PendingItemRowCallbacks(
+    val onClick: () -> Unit,
+    val onLongClick: () -> Unit,
+    val onDeleteRequested: () -> Unit
+)
+
 private data class ShoppingItemRowInteractions(
     val onClick: () -> Unit,
+    val onLongClick: () -> Unit = {},
     val onDeleteRequested: () -> Unit,
     val swipeTag: String,
     val swipeResetTrigger: String
@@ -125,8 +134,7 @@ private data class ShoppingItemRowInteractions(
 
 private data class ShoppingListContentLayout(
     val innerPadding: PaddingValues,
-    val inputBarHeight: Dp,
-    val bulkFabBottomClearance: Dp
+    val inputBarHeight: Dp
 )
 
 internal val shoppingListWideSurfaceShape: Shape = RoundedCornerShape(percent = 50)
@@ -187,8 +195,11 @@ fun ShoppingListRoute(
     val itemCallbacks = remember(viewModel) {
         ShoppingListItemCallbacks(
             onPendingItemClick = viewModel::onPendingItemClicked,
+            onPendingItemLongPress = viewModel::onPendingItemLongPressed,
             onPurchasedItemClick = viewModel::onPurchasedItemClicked,
             onPurchaseSelectedItems = viewModel::onPurchaseSelectedItems,
+            onDeleteSelectedItems = viewModel::onDeleteSelectedItems,
+            onSelectionModeExited = viewModel::onSelectionModeExited,
             onDeleteItemRequested = viewModel::onDeleteItemRequested,
             onDeleteItemDismissed = viewModel::onDeleteItemDismissed,
             onDeleteItemConfirmed = viewModel::onDeleteItemConfirmed
@@ -224,9 +235,6 @@ fun ShoppingListScreen(
     val focusManager = LocalFocusManager.current
     var inputBarContentHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
-    val bulkFabBottomClearance = with(density) {
-        if (inputBarContentHeightPx > 0) inputBarContentHeightPx.toDp() + 16.dp else 88.dp
-    }
 
     LaunchedEffect(Unit) {
         focusManager.clearFocus(force = true)
@@ -240,6 +248,7 @@ fun ShoppingListScreen(
         topBar = {
             ShoppingListTopAppBar(
                 uiState = uiState,
+                itemCallbacks = itemCallbacks,
                 syncCallbacks = syncCallbacks
             )
         },
@@ -251,8 +260,7 @@ fun ShoppingListScreen(
                 innerPadding = innerPadding,
                 inputBarHeight = with(density) {
                     if (inputBarContentHeightPx > 0) inputBarContentHeightPx.toDp() else 0.dp
-                },
-                bulkFabBottomClearance = bulkFabBottomClearance
+                }
             ),
             inputCallbacks = inputCallbacks,
             itemCallbacks = itemCallbacks,
@@ -301,13 +309,6 @@ private fun ShoppingListScreenContent(
             onContentHeightChanged = onInputBarHeightChanged,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
-
-        BulkPurchaseFab(
-            visible = uiState.isBulkActionVisible,
-            onClick = itemCallbacks.onPurchaseSelectedItems,
-            bottomClearance = layout.bulkFabBottomClearance,
-            modifier = Modifier.align(Alignment.BottomEnd)
-        )
     }
 
     DeleteItemDialog(
@@ -321,57 +322,148 @@ private fun ShoppingListScreenContent(
 @Composable
 private fun ShoppingListTopAppBar(
     uiState: ShoppingListUiState,
+    itemCallbacks: ShoppingListItemCallbacks,
+    syncCallbacks: ShoppingListSyncCallbacks
+) {
+    TopAppBar(
+        title = {
+            if (uiState.isSelectionMode) {
+                Text(text = uiState.selectedIds.size.toString())
+            }
+        },
+        navigationIcon = {
+            ShoppingListNavigationIcon(
+                isSelectionMode = uiState.isSelectionMode,
+                onSelectionModeExited = itemCallbacks.onSelectionModeExited
+            )
+        },
+        actions = {
+            ShoppingListTopBarActions(
+                uiState = uiState,
+                itemCallbacks = itemCallbacks,
+                syncCallbacks = syncCallbacks
+            )
+        }
+    )
+}
+
+@Composable
+private fun ShoppingListNavigationIcon(
+    isSelectionMode: Boolean,
+    onSelectionModeExited: () -> Unit
+) {
+    if (isSelectionMode) {
+        val exitSelectionModeLabel = stringResource(R.string.exit_selection_mode)
+
+        IconButton(
+            onClick = onSelectionModeExited,
+            modifier = Modifier
+                .testTag(ShoppingListTestTags.EXIT_SELECTION_BUTTON)
+                .semantics { contentDescription = exitSelectionModeLabel }
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Close,
+                contentDescription = null
+            )
+        }
+        return
+    }
+
+    Icon(
+        imageVector = Icons.Rounded.ShoppingBag,
+        contentDescription = stringResource(R.string.shopping_list_title),
+        tint = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .padding(start = 16.dp)
+            .size(28.dp)
+            .testTag(ShoppingListTestTags.BRAND_ICON)
+    )
+}
+
+@Composable
+private fun ShoppingListTopBarActions(
+    uiState: ShoppingListUiState,
+    itemCallbacks: ShoppingListItemCallbacks,
+    syncCallbacks: ShoppingListSyncCallbacks
+) {
+    if (uiState.isSelectionMode) {
+        SelectionModeActions(itemCallbacks = itemCallbacks)
+    } else {
+        DefaultTopBarActions(
+            uiState = uiState,
+            syncCallbacks = syncCallbacks
+        )
+    }
+}
+
+@Composable
+private fun SelectionModeActions(itemCallbacks: ShoppingListItemCallbacks) {
+    val purchaseSelectedLabel = stringResource(R.string.purchase_selected_items)
+    val deleteSelectedLabel = stringResource(R.string.delete_selected_items)
+
+    IconButton(
+        onClick = itemCallbacks.onPurchaseSelectedItems,
+        modifier = Modifier
+            .testTag(ShoppingListTestTags.PURCHASE_SELECTED_BUTTON)
+            .semantics { contentDescription = purchaseSelectedLabel }
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Check,
+            contentDescription = null
+        )
+    }
+    IconButton(
+        onClick = itemCallbacks.onDeleteSelectedItems,
+        modifier = Modifier
+            .testTag(ShoppingListTestTags.DELETE_SELECTED_BUTTON)
+            .semantics { contentDescription = deleteSelectedLabel }
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Delete,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+private fun DefaultTopBarActions(
+    uiState: ShoppingListUiState,
     syncCallbacks: ShoppingListSyncCallbacks
 ) {
     val syncNowLabel = stringResource(R.string.sync_now)
 
-    TopAppBar(
-        title = {},
-        navigationIcon = {
-            Icon(
-                imageVector = Icons.Rounded.ShoppingBag,
-                contentDescription = stringResource(R.string.shopping_list_title),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(start = 16.dp)
-                    .size(28.dp)
-                    .testTag(ShoppingListTestTags.BRAND_ICON)
-            )
-        },
-        actions = {
-            if (uiState.isSyncConfigured) {
-                IconButton(
-                    onClick = syncCallbacks.onManualSyncRequested,
+    if (uiState.isSyncConfigured) {
+        IconButton(
+            onClick = syncCallbacks.onManualSyncRequested,
+            modifier = Modifier
+                .testTag(ShoppingListTestTags.SYNC_BADGE)
+                .semantics { contentDescription = syncNowLabel }
+        ) {
+            if (uiState.isManualSync || uiState.isBackgroundSync) {
+                CircularProgressIndicator(
                     modifier = Modifier
-                        .testTag(ShoppingListTestTags.SYNC_BADGE)
-                        .semantics { contentDescription = syncNowLabel }
-                ) {
-                    if (uiState.isManualSync || uiState.isBackgroundSync) {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .size(18.dp)
-                                .testTag(ShoppingListTestTags.SYNC_BADGE_SPINNER),
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Rounded.Sync,
-                            contentDescription = null
-                        )
-                    }
-                }
-            }
-            IconButton(
-                onClick = syncCallbacks.onSyncSettingsClicked,
-                modifier = Modifier.testTag(ShoppingListTestTags.SYNC_SETTINGS_BUTTON)
-            ) {
+                        .size(18.dp)
+                        .testTag(ShoppingListTestTags.SYNC_BADGE_SPINNER),
+                    strokeWidth = 2.dp
+                )
+            } else {
                 Icon(
-                    imageVector = Icons.Rounded.Settings,
-                    contentDescription = stringResource(R.string.sync_settings)
+                    imageVector = Icons.Rounded.Sync,
+                    contentDescription = null
                 )
             }
         }
-    )
+    }
+
+    IconButton(
+        onClick = syncCallbacks.onSyncSettingsClicked,
+        modifier = Modifier.testTag(ShoppingListTestTags.SYNC_SETTINGS_BUTTON)
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Settings,
+            contentDescription = stringResource(R.string.sync_settings)
+        )
+    }
 }
 
 
@@ -495,35 +587,6 @@ private fun ShoppingSuggestionsList(
 }
 
 @Composable
-private fun BulkPurchaseFab(
-    visible: Boolean,
-    onClick: () -> Unit,
-    bottomClearance: Dp,
-    modifier: Modifier = Modifier
-) {
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(),
-        exit = fadeOut(),
-        modifier = modifier
-            .navigationBarsPadding()
-            .imePadding()
-            .padding(end = 16.dp, bottom = bottomClearance)
-    ) {
-        FloatingActionButton(
-            onClick = onClick,
-            modifier = Modifier.testTag(ShoppingListTestTags.PURCHASE_SELECTED_FAB),
-            shape = CircleShape
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.Check,
-                contentDescription = stringResource(R.string.purchase_selected_items)
-            )
-        }
-    }
-}
-
-@Composable
 private fun ShoppingItemsContent(
     uiState: ShoppingListUiState,
     itemCallbacks: ShoppingListItemCallbacks,
@@ -594,15 +657,18 @@ private fun androidx.compose.foundation.lazy.LazyListScope.pendingItemsSection(
         return
     }
 
-        items(
+    items(
         items = pendingItems,
         key = { item -> item.id }
     ) { item ->
         PendingItemRow(
             item = item,
             isSelected = item.id in selectedIds,
-            onClick = { itemCallbacks.onPendingItemClick(item.id) },
-            onDeleteRequested = { itemCallbacks.onDeleteItemRequested(item) },
+            callbacks = PendingItemRowCallbacks(
+                onClick = { itemCallbacks.onPendingItemClick(item.id) },
+                onLongClick = { itemCallbacks.onPendingItemLongPress(item.id) },
+                onDeleteRequested = { itemCallbacks.onDeleteItemRequested(item) }
+            ),
             swipeResetTrigger = swipeResetTrigger,
             iconResolver = iconResolver,
             modifier = Modifier.animateItem()
@@ -704,8 +770,7 @@ private fun EmptyStateCard(
 private fun PendingItemRow(
     item: ShoppingItem,
     isSelected: Boolean,
-    onClick: () -> Unit,
-    onDeleteRequested: () -> Unit,
+    callbacks: PendingItemRowCallbacks,
     swipeResetTrigger: String,
     iconResolver: IconResolver,
     modifier: Modifier = Modifier
@@ -735,8 +800,9 @@ private fun PendingItemRow(
             contentColor = contentColor
         ),
         interactions = ShoppingItemRowInteractions(
-            onClick = onClick,
-            onDeleteRequested = onDeleteRequested,
+            onClick = callbacks.onClick,
+            onLongClick = callbacks.onLongClick,
+            onDeleteRequested = callbacks.onDeleteRequested,
             swipeTag = ShoppingListTestTags.swipePendingItem(item.id),
             swipeResetTrigger = swipeResetTrigger
         ),
@@ -826,7 +892,10 @@ private fun ShoppingItemRow(
                 .background(visuals.containerColor)
                 .heightIn(min = 56.dp)
                 .padding(horizontal = 16.dp)
-                .clickable(onClick = interactions.onClick),
+                .combinedClickable(
+                    onClick = interactions.onClick,
+                    onLongClick = interactions.onLongClick
+                ),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
@@ -3,7 +3,6 @@ package com.jhow.shopplist.presentation.shoppinglist
 object ShoppingListTestTags {
     const val SCREEN = "shopping_list_screen"
     const val INPUT_FIELD = "shopping_list_input"
-    const val PURCHASE_SELECTED_FAB = "purchase_selected_fab"
     const val PENDING_SECTION = "pending_section"
     const val PURCHASED_SECTION = "purchased_section"
     const val SECTION_DIVIDER = "shopping_list_divider"
@@ -27,6 +26,9 @@ object ShoppingListTestTags {
     const val SYNC_STATE_TEXT = "sync_state_text"
     const val SYNC_SETTINGS_SHEET_CONTENT = "sync_settings_sheet_content"
     const val SYNC_PROGRESS_INDICATOR = "sync_progress_indicator"
+    const val EXIT_SELECTION_BUTTON = "exit_selection_button"
+    const val PURCHASE_SELECTED_BUTTON = "purchase_selected_button"
+    const val DELETE_SELECTED_BUTTON = "delete_selected_button"
 
     fun pendingItem(id: String): String = "pending_item_$id"
 

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiState.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiState.kt
@@ -10,11 +10,12 @@ data class ShoppingListUiState(
     val pendingItems: List<ShoppingItem> = emptyList(),
     val purchasedItems: List<ShoppingItem> = emptyList(),
     val selectedIds: Set<String> = emptySet(),
+    val isSelectionMode: Boolean = false,
     val itemPendingDeletion: ShoppingItem? = null,
     val isManualSync: Boolean = false,
     val isBackgroundSync: Boolean = false,
     val isSyncConfigured: Boolean = false
 ) {
     val isBulkActionVisible: Boolean
-        get() = selectedIds.isNotEmpty()
+        get() = isSelectionMode
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
@@ -126,14 +126,19 @@ class ShoppingListViewModel @Inject constructor(
             val pendingIds = intermediate.pendingItems.mapTo(linkedSetOf()) { it.id }
             val distinctPurchasedItems = intermediate.purchasedItems.filterNot { it.id in pendingIds }
             val visibleItems = intermediate.pendingItems + distinctPurchasedItems
+            val visibleSelectedIds = intermediate.selectedIds.intersect(pendingIds)
+
+            if (visibleSelectedIds != intermediate.selectedIds) {
+                selectionController.retainOnly(pendingIds)
+            }
 
             ShoppingListUiState(
                 inputValue = intermediate.currentInput,
                 suggestions = intermediate.currentSuggestions,
                 pendingItems = intermediate.pendingItems,
                 purchasedItems = distinctPurchasedItems,
-                selectedIds = intermediate.selectedIds.intersect(pendingIds),
-                isSelectionMode = intermediate.isSelectionMode && intermediate.selectedIds.any { it in pendingIds },
+                selectedIds = visibleSelectedIds,
+                isSelectionMode = intermediate.isSelectionMode && visibleSelectedIds.isNotEmpty(),
                 itemPendingDeletion = visibleItems.firstOrNull { it.id == intermediate.itemPendingDeletion?.id },
                 isManualSync = syncing && latch,
                 isBackgroundSync = syncing && !latch,

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
@@ -35,6 +35,7 @@ private data class ShoppingListIntermediateState(
     val currentInput: String,
     val currentSuggestions: List<String>,
     val selectedIds: Set<String>,
+    val isSelectionMode: Boolean,
     val itemPendingDeletion: ShoppingItem?
 )
 
@@ -50,29 +51,43 @@ class ShoppingListViewModel @Inject constructor(
     private val markPurchasedItemPendingUseCase: MarkPurchasedItemPendingUseCase,
     private val requestShoppingSyncUseCase: RequestShoppingSyncUseCase,
     observeSyncStateUseCase: ObserveSyncStateUseCase,
-    getCalDavSyncConfigUseCase: GetCalDavSyncConfigUseCase
+    getCalDavSyncConfigUseCase: GetCalDavSyncConfigUseCase,
+    private val selectionController: SelectionController
 ) : ViewModel() {
     private val inputValue = MutableStateFlow("")
-    private val selectedIds = MutableStateFlow(emptySet<String>())
     private val itemPendingDeletion = MutableStateFlow<ShoppingItem?>(null)
     private val inputWithSuggestions = combine(observeItemNamesUseCase(), inputValue) { allItemNames, currentInput ->
         currentInput to buildSuggestions(allItemNames = allItemNames, currentInput = currentInput)
     }
 
-    private val combinedState = combine(
-        observePendingItemsUseCase(),
-        observePurchasedItemsUseCase(),
+    private val viewSignals = combine(
         inputWithSuggestions,
-        selectedIds,
+        selectionController.selected,
+        selectionController.isActive,
         itemPendingDeletion
-    ) { pendingItems, purchasedItems, inputSuggestions, selectedIds, itemPendingDeletion ->
-        ShoppingListIntermediateState(
-            pendingItems = pendingItems,
-            purchasedItems = purchasedItems,
+    ) { inputSuggestions, selectedIds, isSelectionMode, pendingDeletion ->
+        ViewSignals(
             currentInput = inputSuggestions.first,
             currentSuggestions = inputSuggestions.second,
             selectedIds = selectedIds,
-            itemPendingDeletion = itemPendingDeletion
+            isSelectionMode = isSelectionMode,
+            itemPendingDeletion = pendingDeletion
+        )
+    }
+
+    private val combinedState = combine(
+        observePendingItemsUseCase(),
+        observePurchasedItemsUseCase(),
+        viewSignals
+    ) { pendingItems, purchasedItems, signals ->
+        ShoppingListIntermediateState(
+            pendingItems = pendingItems,
+            purchasedItems = purchasedItems,
+            currentInput = signals.currentInput,
+            currentSuggestions = signals.currentSuggestions,
+            selectedIds = signals.selectedIds,
+            isSelectionMode = signals.isSelectionMode,
+            itemPendingDeletion = signals.itemPendingDeletion
         )
     }
 
@@ -118,6 +133,7 @@ class ShoppingListViewModel @Inject constructor(
                 pendingItems = intermediate.pendingItems,
                 purchasedItems = distinctPurchasedItems,
                 selectedIds = intermediate.selectedIds.intersect(pendingIds),
+                isSelectionMode = intermediate.isSelectionMode && intermediate.selectedIds.any { it in pendingIds },
                 itemPendingDeletion = visibleItems.firstOrNull { it.id == intermediate.itemPendingDeletion?.id },
                 isManualSync = syncing && latch,
                 isBackgroundSync = syncing && !latch,
@@ -150,26 +166,55 @@ class ShoppingListViewModel @Inject constructor(
     }
 
     fun onPendingItemClicked(id: String) {
-        selectedIds.update { currentIds ->
-            if (id in currentIds) currentIds - id else currentIds + id
+        if (selectionController.isActive.value) {
+            selectionController.toggle(id)
+            return
+        }
+
+        viewModelScope.launch {
+            markSelectedItemsPurchasedUseCase(setOf(id))
+            requestSync()
         }
     }
 
+    fun onPendingItemLongPressed(id: String) {
+        selectionController.enter(id)
+    }
+
     fun onPurchaseSelectedItems() {
-        val ids = selectedIds.value
+        val ids = selectionController.selected.value
         if (ids.isEmpty()) return
 
         viewModelScope.launch {
             markSelectedItemsPurchasedUseCase(ids)
-            selectedIds.value = emptySet()
+            selectionController.exit()
             requestSync()
         }
+    }
+
+    fun onDeleteSelectedItems() {
+        val ids = selectionController.selected.value
+        if (ids.isEmpty()) return
+
+        viewModelScope.launch {
+            ids.forEach { id ->
+                deleteShoppingItemUseCase(id)
+            }
+            selectionController.exit()
+            requestSync()
+        }
+    }
+
+    fun onSelectionModeExited() {
+        selectionController.exit()
     }
 
     fun onPurchasedItemClicked(id: String) {
         viewModelScope.launch {
             markPurchasedItemPendingUseCase(id)
-            selectedIds.update { it - id }
+            if (id in selectionController.selected.value) {
+                selectionController.toggle(id)
+            }
             requestSync()
         }
     }
@@ -187,7 +232,9 @@ class ShoppingListViewModel @Inject constructor(
 
         viewModelScope.launch {
             deleteShoppingItemUseCase(item.id)
-            selectedIds.update { it - item.id }
+            if (item.id in selectionController.selected.value) {
+                selectionController.toggle(item.id)
+            }
             itemPendingDeletion.value = null
             requestSync()
         }
@@ -243,4 +290,12 @@ class ShoppingListViewModel @Inject constructor(
             val score: Int
         )
     }
+
+    private data class ViewSignals(
+        val currentInput: String,
+        val currentSuggestions: List<String>,
+        val selectedIds: Set<String>,
+        val isSelectionMode: Boolean,
+        val itemPendingDeletion: ShoppingItem?
+    )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="add_item_label">Add item</string>
     <string name="add_item_placeholder">Milk, coffee, tomatoes\u2026</string>
     <string name="purchase_selected_items">Mark selected items as purchased</string>
+    <string name="delete_selected_items">Delete selected items</string>
+    <string name="exit_selection_mode">Exit selection mode</string>
     <string name="pending_items_title">Pending items</string>
     <string name="purchased_items_title">Purchased history</string>
     <string name="empty_pending_title">Nothing pending yet</string>

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/SelectionControllerTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/SelectionControllerTest.kt
@@ -57,4 +57,14 @@ class SelectionControllerTest {
         assertFalse(controller.isActive.value)
         assertEquals(emptySet<String>(), controller.selected.value)
     }
+
+    @Test
+    fun `retaining only valid ids exits when selection becomes empty`() {
+        controller.enter("milk")
+
+        controller.retainOnly(setOf("tea"))
+
+        assertFalse(controller.isActive.value)
+        assertEquals(emptySet<String>(), controller.selected.value)
+    }
 }

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/SelectionControllerTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/SelectionControllerTest.kt
@@ -1,0 +1,60 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelectionControllerTest {
+    private val controller = SelectionController()
+
+    @Test
+    fun `long press entry activates selection mode with pressed item selected`() {
+        controller.enter("milk")
+
+        assertTrue(controller.isActive.value)
+        assertEquals(setOf("milk"), controller.selected.value)
+    }
+
+    @Test
+    fun `tapping while selection mode is active toggles item membership`() {
+        controller.enter("milk")
+
+        controller.toggle("tea")
+        assertEquals(setOf("milk", "tea"), controller.selected.value)
+
+        controller.toggle("tea")
+        assertEquals(setOf("milk"), controller.selected.value)
+    }
+
+    @Test
+    fun `emptying the selection exits selection mode`() {
+        controller.enter("milk")
+
+        controller.toggle("milk")
+
+        assertFalse(controller.isActive.value)
+        assertEquals(emptySet<String>(), controller.selected.value)
+    }
+
+    @Test
+    fun `enter is idempotent while selection mode is already active`() {
+        controller.enter("milk")
+
+        controller.enter("tea")
+
+        assertTrue(controller.isActive.value)
+        assertEquals(setOf("milk"), controller.selected.value)
+    }
+
+    @Test
+    fun `exit clears a non empty selection`() {
+        controller.enter("milk")
+        controller.toggle("tea")
+
+        controller.exit()
+
+        assertFalse(controller.isActive.value)
+        assertEquals(emptySet<String>(), controller.selected.value)
+    }
+}

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiStateTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiStateTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class ShoppingListUiStateTest {
     @Test
     fun `bulk action is visible when selection exists`() {
-        val uiState = ShoppingListUiState(selectedIds = setOf("item-1"))
+        val uiState = ShoppingListUiState(selectedIds = setOf("item-1"), isSelectionMode = true)
 
         assertTrue(uiState.isBulkActionVisible)
     }

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
@@ -35,6 +35,7 @@ class ShoppingListViewModelTest {
     private lateinit var repository: FakeShoppingListRepository
     private lateinit var syncScheduler: FakeShoppingSyncScheduler
     private lateinit var calDavConfigRepository: FakeCalDavConfigRepository
+    private lateinit var selectionController: SelectionController
     private lateinit var viewModel: ShoppingListViewModel
 
     @Before
@@ -42,6 +43,7 @@ class ShoppingListViewModelTest {
         repository = FakeShoppingListRepository()
         syncScheduler = FakeShoppingSyncScheduler()
         calDavConfigRepository = FakeCalDavConfigRepository()
+        selectionController = SelectionController()
         viewModel = ShoppingListViewModel(
             observePendingItemsUseCase = ObservePendingItemsUseCase(repository),
             observePurchasedItemsUseCase = ObservePurchasedItemsUseCase(repository),
@@ -52,7 +54,8 @@ class ShoppingListViewModelTest {
             markPurchasedItemPendingUseCase = MarkPurchasedItemPendingUseCase(repository),
             requestShoppingSyncUseCase = RequestShoppingSyncUseCase(syncScheduler),
             observeSyncStateUseCase = ObserveSyncStateUseCase(syncScheduler),
-            getCalDavSyncConfigUseCase = GetCalDavSyncConfigUseCase(calDavConfigRepository)
+            getCalDavSyncConfigUseCase = GetCalDavSyncConfigUseCase(calDavConfigRepository),
+            selectionController = selectionController
         )
     }
 
@@ -188,17 +191,16 @@ class ShoppingListViewModelTest {
     }
 
     @Test
-    fun `pending item click toggles selection`() = runTest {
+    fun `pending item click marks item purchased immediately`() = runTest {
         repository.seedItems(listOf(samplePendingItem(id = "rice")))
         advanceUntilIdle()
 
         viewModel.onPendingItemClicked("rice")
         advanceUntilIdle()
-        assertEquals(setOf("rice"), viewModel.uiState.value.selectedIds)
 
-        viewModel.onPendingItemClicked("rice")
-        advanceUntilIdle()
-        assertEquals(emptySet<String>(), viewModel.uiState.value.selectedIds)
+        assertEquals(listOf(setOf("rice")), repository.purchasedRequests)
+        assertEquals(listOf("rice"), viewModel.uiState.value.purchasedItems.map { it.id })
+        assertEquals(1, syncScheduler.requestCount)
     }
 
     @Test
@@ -211,7 +213,7 @@ class ShoppingListViewModelTest {
         )
         advanceUntilIdle()
 
-        viewModel.onPendingItemClicked("milk")
+        viewModel.onPendingItemLongPressed("milk")
         viewModel.onPendingItemClicked("tea")
         advanceUntilIdle()
 
@@ -229,11 +231,101 @@ class ShoppingListViewModelTest {
         repository.seedItems(listOf(samplePendingItem(id = "eggs")))
         advanceUntilIdle()
 
-        viewModel.onPendingItemClicked("eggs")
+        viewModel.onPendingItemLongPressed("eggs")
         advanceUntilIdle()
         repository.seedItems(listOf(samplePurchasedItem(id = "eggs")))
         advanceUntilIdle()
 
+        assertEquals(emptySet<String>(), viewModel.uiState.value.selectedIds)
+    }
+
+    @Test
+    fun `long pressing pending item enters multi select with item selected`() = runTest {
+        repository.seedItems(listOf(samplePendingItem(id = "rice")))
+        advanceUntilIdle()
+
+        viewModel.onPendingItemLongPressed("rice")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isSelectionMode)
+        assertEquals(setOf("rice"), viewModel.uiState.value.selectedIds)
+    }
+
+    @Test
+    fun `pending item click toggles selection while multi select is active`() = runTest {
+        repository.seedItems(
+            listOf(
+                samplePendingItem(id = "rice"),
+                samplePendingItem(id = "beans")
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onPendingItemLongPressed("rice")
+        advanceUntilIdle()
+        viewModel.onPendingItemClicked("beans")
+        advanceUntilIdle()
+
+        assertEquals(setOf("rice", "beans"), viewModel.uiState.value.selectedIds)
+        assertTrue(repository.purchasedRequests.isEmpty())
+    }
+
+    @Test
+    fun `selection mode exits when toggling leaves selection empty`() = runTest {
+        repository.seedItems(listOf(samplePendingItem(id = "rice")))
+        advanceUntilIdle()
+
+        viewModel.onPendingItemLongPressed("rice")
+        advanceUntilIdle()
+        viewModel.onPendingItemClicked("rice")
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSelectionMode)
+        assertEquals(emptySet<String>(), viewModel.uiState.value.selectedIds)
+    }
+
+    @Test
+    fun `exiting selection mode clears selected ids`() = runTest {
+        repository.seedItems(
+            listOf(
+                samplePendingItem(id = "rice"),
+                samplePendingItem(id = "beans")
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onPendingItemLongPressed("rice")
+        advanceUntilIdle()
+        viewModel.onPendingItemClicked("beans")
+        advanceUntilIdle()
+
+        viewModel.onSelectionModeExited()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSelectionMode)
+        assertEquals(emptySet<String>(), viewModel.uiState.value.selectedIds)
+    }
+
+    @Test
+    fun `delete selected items removes selected rows and exits selection mode`() = runTest {
+        repository.seedItems(
+            listOf(
+                samplePendingItem(id = "rice"),
+                samplePendingItem(id = "beans")
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onPendingItemLongPressed("rice")
+        advanceUntilIdle()
+        viewModel.onPendingItemClicked("beans")
+        advanceUntilIdle()
+
+        viewModel.onDeleteSelectedItems()
+        advanceUntilIdle()
+
+        assertEquals(listOf("rice", "beans"), repository.deletedRequests)
+        assertFalse(viewModel.uiState.value.isSelectionMode)
         assertEquals(emptySet<String>(), viewModel.uiState.value.selectedIds)
     }
 

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
@@ -240,6 +240,36 @@ class ShoppingListViewModelTest {
     }
 
     @Test
+    fun `clicking pending item after stale selection disappears marks it purchased`() = runTest {
+        repository.seedItems(
+            listOf(
+                samplePendingItem(id = "eggs"),
+                samplePendingItem(id = "rice")
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onPendingItemLongPressed("eggs")
+        advanceUntilIdle()
+        repository.seedItems(
+            listOf(
+                samplePurchasedItem(id = "eggs"),
+                samplePendingItem(id = "rice")
+            )
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSelectionMode)
+        assertEquals(emptySet<String>(), viewModel.uiState.value.selectedIds)
+
+        viewModel.onPendingItemClicked("rice")
+        advanceUntilIdle()
+
+        assertEquals(listOf(setOf("rice")), repository.purchasedRequests)
+        assertEquals(1, syncScheduler.requestCount)
+    }
+
+    @Test
     fun `long pressing pending item enters multi select with item selected`() = runTest {
         repository.seedItems(listOf(samplePendingItem(id = "rice")))
         advanceUntilIdle()


### PR DESCRIPTION
## Summary
- switch pending-row interactions to one-tap purchase with long-press entry into multi-select backed by a new pure `SelectionController`
- replace the bulk purchase FAB with contextual top-bar purchase and delete actions shown only while selection mode is active
- update unit and instrumented shopping-list coverage for the new action model and verify the issue-57 slice on Emulator-1

## Verification
- `./gradlew lintDebug`
- `./gradlew testDebugUnitTest`
- `ANDROID_SERIAL=emulator-5554 ./gradlew connectedDebugAndroidTest -Pandroid.injected.androidTest.leaveApksInstalledAfterRun=true`
- `ANDROID_SERIAL=emulator-5554 ./gradlew verifyDebugCoverage -Pandroid.injected.androidTest.leaveApksInstalledAfterRun=true`
- `adb -s emulator-5554 shell am instrument -w -e class com.jhow.shopplist.presentation.shoppinglist.ShoppingListTopBarTest,com.jhow.shopplist.presentation.shoppinglist.ShoppingListScreenTest com.jhow.shopplist.debug.test/androidx.test.runner.AndroidJUnitRunner`

## Links
- PRD: #55
- Task: #57

Closes #57