### PR TITLE
Phase 1 · CalDAV settings keyboard flow polish

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreenTest.kt
@@ -2,10 +2,13 @@ package com.jhow.shopplist.presentation.caldavconfig
 
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.compose.runtime.getValue
@@ -97,6 +100,58 @@ class CalDavConfigScreenTest {
 
         composeRule.onNodeWithTag(CalDavConfigTestTags.SAVE_BUTTON).performClick()
         assertTrue(saveClicked)
+    }
+
+    @Test
+    fun imeActions_moveFocusThroughFieldsAndSubmitOnDone() {
+        var saveClicked = false
+
+        composeRule.setContent {
+            CalDavConfigScreen(
+                uiState = CalDavConfigUiState(isLoading = false),
+                callbacks = CalDavConfigCallbacks(
+                    onSaveClicked = { saveClicked = true }
+                )
+            )
+        }
+
+        composeRule.onNodeWithTag(CalDavConfigTestTags.SERVER_FIELD).performClick()
+        composeRule.onNodeWithTag(CalDavConfigTestTags.SERVER_FIELD).assertIsFocused()
+        composeRule.onNodeWithTag(CalDavConfigTestTags.SERVER_FIELD).performImeAction()
+        composeRule.onNodeWithTag(CalDavConfigTestTags.USERNAME_FIELD).assertIsFocused()
+
+        composeRule.onNodeWithTag(CalDavConfigTestTags.USERNAME_FIELD).performImeAction()
+        composeRule.onNodeWithTag(CalDavConfigTestTags.PASSWORD_FIELD).assertIsFocused()
+
+        composeRule.onNodeWithTag(CalDavConfigTestTags.PASSWORD_FIELD).performImeAction()
+        composeRule.onNodeWithTag(CalDavConfigTestTags.LIST_NAME_FIELD).assertIsFocused()
+
+        composeRule.onNodeWithTag(CalDavConfigTestTags.LIST_NAME_FIELD).performImeAction()
+
+        assertTrue(saveClicked)
+    }
+
+    @Test
+    fun passwordVisibilityToggle_switchesBetweenShowAndHideStates() {
+        composeRule.setContent {
+            var state by remember { mutableStateOf(CalDavConfigUiState(isLoading = false)) }
+
+            CalDavConfigScreen(
+                uiState = state,
+                callbacks = CalDavConfigCallbacks(
+                    onPasswordChanged = {
+                        state = state.copy(password = it)
+                    }
+                )
+            )
+        }
+
+        composeRule.onNodeWithTag(CalDavConfigTestTags.PASSWORD_FIELD).performTextInput("secret")
+        composeRule.onNodeWithContentDescription("Show password").assertIsDisplayed()
+
+        composeRule.onNodeWithTag(CalDavConfigTestTags.PASSWORD_VISIBILITY_TOGGLE).performClick()
+
+        composeRule.onNodeWithContentDescription("Hide password").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreen.kt
@@ -11,14 +11,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,13 +37,20 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -149,6 +160,7 @@ private fun CalDavConfigFormContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .imePadding()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -214,6 +226,8 @@ private fun CalDavConfigFields(
     callbacks: CalDavConfigCallbacks
 ) {
     val fieldsEnabled = !uiState.isSaving && !uiState.isLoading
+    val focusManager = LocalFocusManager.current
+    var isPasswordVisible by rememberSaveable { mutableStateOf(false) }
 
     OutlinedTextField(
         value = uiState.serverUrl,
@@ -223,6 +237,13 @@ private fun CalDavConfigFields(
             .fillMaxWidth()
             .testTag(CalDavConfigTestTags.SERVER_FIELD),
         singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Uri,
+            imeAction = ImeAction.Next
+        ),
+        keyboardActions = KeyboardActions(
+            onNext = { focusManager.moveFocus(FocusDirection.Next) }
+        ),
         enabled = fieldsEnabled
     )
 
@@ -234,25 +255,19 @@ private fun CalDavConfigFields(
             .fillMaxWidth()
             .testTag(CalDavConfigTestTags.USERNAME_FIELD),
         singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+        keyboardActions = KeyboardActions(
+            onNext = { focusManager.moveFocus(FocusDirection.Next) }
+        ),
         enabled = fieldsEnabled
     )
 
-    OutlinedTextField(
-        value = uiState.password,
+    PasswordField(
+        uiState = uiState,
         onValueChange = callbacks.onPasswordChanged,
-        label = { Text(stringResource(R.string.sync_password_label)) },
-        placeholder = {
-            if (uiState.hasStoredPassword && uiState.password.isBlank()) {
-                Text(stringResource(R.string.sync_password_saved_placeholder))
-            }
-        },
-        visualTransformation = PasswordVisualTransformation(),
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag(CalDavConfigTestTags.PASSWORD_FIELD),
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-        enabled = fieldsEnabled
+        isPasswordVisible = isPasswordVisible,
+        onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
+        onNext = { focusManager.moveFocus(FocusDirection.Next) }
     )
 
     OutlinedTextField(
@@ -263,6 +278,69 @@ private fun CalDavConfigFields(
             .fillMaxWidth()
             .testTag(CalDavConfigTestTags.LIST_NAME_FIELD),
         singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(
+            onDone = { callbacks.onSaveClicked() }
+        ),
+        enabled = fieldsEnabled
+    )
+}
+
+@Composable
+private fun PasswordField(
+    uiState: CalDavConfigUiState,
+    onValueChange: (String) -> Unit,
+    isPasswordVisible: Boolean,
+    onPasswordVisibilityChange: () -> Unit,
+    onNext: () -> Unit
+) {
+    val fieldsEnabled = !uiState.isSaving && !uiState.isLoading
+
+    OutlinedTextField(
+        value = uiState.password,
+        onValueChange = onValueChange,
+        label = { Text(stringResource(R.string.sync_password_label)) },
+        placeholder = {
+            if (uiState.hasStoredPassword && uiState.password.isBlank()) {
+                Text(stringResource(R.string.sync_password_saved_placeholder))
+            }
+        },
+        visualTransformation = if (isPasswordVisible) {
+            VisualTransformation.None
+        } else {
+            PasswordVisualTransformation()
+        },
+        trailingIcon = {
+            IconButton(
+                onClick = onPasswordVisibilityChange,
+                enabled = fieldsEnabled,
+                modifier = Modifier.testTag(CalDavConfigTestTags.PASSWORD_VISIBILITY_TOGGLE)
+            ) {
+                Icon(
+                    imageVector = if (isPasswordVisible) {
+                        Icons.Rounded.VisibilityOff
+                    } else {
+                        Icons.Rounded.Visibility
+                    },
+                    contentDescription = stringResource(
+                        if (isPasswordVisible) {
+                            R.string.sync_password_hide
+                        } else {
+                            R.string.sync_password_show
+                        }
+                    )
+                )
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(CalDavConfigTestTags.PASSWORD_FIELD),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Password,
+            imeAction = ImeAction.Next
+        ),
+        keyboardActions = KeyboardActions(onNext = { onNext() }),
         enabled = fieldsEnabled
     )
 }
@@ -282,7 +360,7 @@ private fun CalDavConfigSuccessContent(
         Icon(
             imageVector = Icons.Rounded.CheckCircle,
             contentDescription = stringResource(R.string.caldav_config_success_icon),
-            tint = Color(0xFF4CAF50.toInt()),
+            tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier
                 .size(96.dp)
                 .testTag(CalDavConfigTestTags.SUCCESS_ICON)

--- a/app/src/main/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigTestTags.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigTestTags.kt
@@ -6,6 +6,7 @@ object CalDavConfigTestTags {
     const val SERVER_FIELD = "caldav_config_server"
     const val USERNAME_FIELD = "caldav_config_username"
     const val PASSWORD_FIELD = "caldav_config_password"
+    const val PASSWORD_VISIBILITY_TOGGLE = "caldav_config_password_visibility_toggle"
     const val LIST_NAME_FIELD = "caldav_config_list_name"
     const val SAVE_BUTTON = "caldav_config_save"
     const val PROGRESS_INDICATOR = "caldav_config_progress"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="sync_server_label">Server</string>
     <string name="sync_username_label">Username</string>
     <string name="sync_password_label">Password</string>
+    <string name="sync_password_show">Show password</string>
+    <string name="sync_password_hide">Hide password</string>
     <string name="sync_list_name_label">List name</string>
     <string name="sync_create_missing_list">Create remote list</string>
     <string name="sync_password_saved_placeholder">Saved password on device</string>


### PR DESCRIPTION
## Summary
- polish the CalDAV form IME flow and keyboard configuration
- add a password visibility toggle and keep the save action above the keyboard
- replace the success icon hardcoded color with a theme color and extend screen coverage

## Testing
- ANDROID_SERIAL=emulator-5560 ./gradlew lintDebug testDebugUnitTest connectedDebugAndroidTest verifyDebugCoverage

Closes #60
Refs #55
