### PR TITLE
Phase 1: Polish composer input behavior

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -1,7 +1,9 @@
 package com.jhow.shopplist.presentation.shoppinglist
 
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -187,6 +189,29 @@ class ShoppingListScreenTest {
         }
 
         assertTrue(composeRule.onAllNodesWithText("Yogurt").fetchSemanticsNodes().isNotEmpty())
+    }
+
+    @Test
+    fun tappingSubmitIconAddsCurrentInputToPendingList() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("Yogurt")
+        composeRule.onNodeWithTag(ShoppingListTestTags.SUBMIT_INPUT_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Yogurt").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(composeRule.onAllNodesWithText("Yogurt").fetchSemanticsNodes().isNotEmpty())
+    }
+
+    @Test
+    fun submitIconIsDisabledUntilInputHasText() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.SUBMIT_INPUT_BUTTON).assertIsNotEnabled()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.INPUT_FIELD).performTextInput("Yogurt")
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.SUBMIT_INPUT_BUTTON).assertIsEnabled()
     }
 
     @Test

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -74,6 +76,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.focus.FocusRequester
@@ -136,6 +139,8 @@ private data class ShoppingListContentLayout(
     val innerPadding: PaddingValues,
     val inputBarHeight: Dp
 )
+
+internal fun shoppingListBottomContentPadding(inputBarHeight: Dp): Dp = inputBarHeight
 
 internal val shoppingListWideSurfaceShape: Shape = RoundedCornerShape(percent = 50)
 
@@ -289,7 +294,8 @@ private fun ShoppingListScreenContent(
             uiState = uiState,
             itemCallbacks = itemCallbacks,
             modifier = Modifier.fillMaxSize(),
-            iconResolver = iconResolver
+            iconResolver = iconResolver,
+            bottomContentPadding = shoppingListBottomContentPadding(layout.inputBarHeight)
         )
 
         if (uiState.isManualSync) {
@@ -521,6 +527,13 @@ private fun ShoppingInputField(
     focusRequester: FocusRequester,
     onContinuousEntryRequested: () -> Unit
 ) {
+    val canSubmit = value.isNotBlank()
+
+    fun submitAndRestoreContinuousEntry() {
+        inputCallbacks.onAddItem()
+        onContinuousEntryRequested()
+    }
+
     OutlinedTextField(
         value = value,
         onValueChange = inputCallbacks.onValueChange,
@@ -532,18 +545,27 @@ private fun ShoppingInputField(
         placeholder = { Text(text = stringResource(R.string.add_item_placeholder)) },
         shape = shoppingListWideSurfaceShape,
         singleLine = true,
-        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Sentences,
+            autoCorrectEnabled = false,
+            imeAction = ImeAction.Done
+        ),
         keyboardActions = KeyboardActions(
             onDone = {
-                inputCallbacks.onAddItem()
-                onContinuousEntryRequested()
+                submitAndRestoreContinuousEntry()
             }
         ),
         trailingIcon = {
-            Icon(
-                imageVector = Icons.Rounded.AddTask,
-                contentDescription = null
-            )
+            IconButton(
+                onClick = ::submitAndRestoreContinuousEntry,
+                enabled = canSubmit,
+                modifier = Modifier.testTag(ShoppingListTestTags.SUBMIT_INPUT_BUTTON)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.AddTask,
+                    contentDescription = stringResource(R.string.add_item_submit)
+                )
+            }
         }
     )
 }
@@ -586,20 +608,24 @@ private fun ShoppingSuggestionsList(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ShoppingItemsContent(
     uiState: ShoppingListUiState,
     itemCallbacks: ShoppingListItemCallbacks,
     modifier: Modifier = Modifier,
-    iconResolver: IconResolver
+    iconResolver: IconResolver,
+    bottomContentPadding: Dp
 ) {
     val swipeResetTrigger = uiState.itemPendingDeletion?.id.orEmpty()
     val emptyPendingTitle = stringResource(R.string.empty_pending_title)
     val emptyPurchasedTitle = stringResource(R.string.empty_purchased_title)
 
     LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 100.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .imeNestedScroll(),
+        contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = bottomContentPadding),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         item(key = ShoppingListTestTags.PENDING_SECTION) {

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
@@ -3,6 +3,7 @@ package com.jhow.shopplist.presentation.shoppinglist
 object ShoppingListTestTags {
     const val SCREEN = "shopping_list_screen"
     const val INPUT_FIELD = "shopping_list_input"
+    const val SUBMIT_INPUT_BUTTON = "submit_input_button"
     const val PENDING_SECTION = "pending_section"
     const val PURCHASED_SECTION = "purchased_section"
     const val SECTION_DIVIDER = "shopping_list_divider"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Jhow Shopp List</string>
     <string name="shopping_list_title">Shopping List</string>
     <string name="add_item_label">Add item</string>
+    <string name="add_item_submit">Add current item</string>
     <string name="add_item_placeholder">Milk, coffee, tomatoes\u2026</string>
     <string name="purchase_selected_items">Mark selected items as purchased</string>
     <string name="delete_selected_items">Delete selected items</string>

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenVisualsTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenVisualsTest.kt
@@ -1,6 +1,7 @@
 package com.jhow.shopplist.presentation.shoppinglist
 
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -33,5 +34,10 @@ class ShoppingListScreenVisualsTest {
             RoundedCornerShape(percent = 50),
             shoppingListWideSurfaceShape
         )
+    }
+
+    @Test
+    fun `list bottom padding follows measured composer height`() {
+        assertEquals(148.dp, shoppingListBottomContentPadding(inputBarHeight = 148.dp))
     }
 }


### PR DESCRIPTION
## Summary

- Turn the shopping-list trailing add icon into a real submit `IconButton` that shares the IME Done submit path.
- Disable the submit button while input is blank and configure grocery-friendly keyboard options.
- Make the main list use `imeNestedScroll()` and derive bottom content padding from the measured composer/suggestion-panel height.

## Scope

Closes #61 only from parent PRD #55.

## Verification

- `./gradlew testDebugUnitTest`
- `./gradlew connectedDebugAndroidTest`
- `./gradlew lintDebug`
- `./gradlew verifyDebugCoverage`

## Review

`@code-reviewer` sub-agent approved the scoped diff before PR publication.