### PR TITLE
feat(caldav): add predictive back handling

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreenTest.kt
@@ -1,6 +1,7 @@
 package com.jhow.shopplist.presentation.caldavconfig
 
-import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
@@ -24,7 +25,7 @@ import org.junit.runner.RunWith
 class CalDavConfigScreenTest {
 
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun initialState_displaysFormFields() {
@@ -100,6 +101,27 @@ class CalDavConfigScreenTest {
 
         composeRule.onNodeWithTag(CalDavConfigTestTags.SAVE_BUTTON).performClick()
         assertTrue(saveClicked)
+    }
+
+    @Test
+    fun systemBack_invokesNavigateBackCallback() {
+        var navigateBackClicked = false
+
+        composeRule.setContent {
+            CalDavConfigScreen(
+                uiState = CalDavConfigUiState(isLoading = false),
+                callbacks = CalDavConfigCallbacks(
+                    onNavigateBack = { navigateBackClicked = true }
+                )
+            )
+        }
+
+        composeRule.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+        composeRule.waitForIdle()
+
+        assertTrue(navigateBackClicked)
     }
 
     @Test

--- a/app/src/main/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/caldavconfig/CalDavConfigScreen.kt
@@ -1,5 +1,7 @@
 package com.jhow.shopplist.presentation.caldavconfig
 
+import androidx.activity.BackEventCompat
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -56,6 +58,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jhow.shopplist.R
 import com.jhow.shopplist.domain.model.CalDavPendingAction
+import kotlinx.coroutines.flow.Flow
 
 @Composable
 fun CalDavConfigRoute(
@@ -99,6 +102,11 @@ fun CalDavConfigScreen(
     modifier: Modifier = Modifier,
     callbacks: CalDavConfigCallbacks = CalDavConfigCallbacks()
 ) {
+    PredictiveBackHandler { progress: Flow<BackEventCompat> ->
+        progress.collect {}
+        callbacks.onNavigateBack()
+    }
+
     Scaffold(
         modifier = modifier
             .fillMaxSize()


### PR DESCRIPTION
## Summary
- wire `PredictiveBackHandler` on `CalDavConfigScreen` so completed system-back gestures route through the existing navigation callback
- keep canceled predictive gestures from navigating by waiting for the back progress flow to complete
- add dispatcher-backed CalDAV screen coverage for system back navigation

## Verification
- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `ANDROID_SERIAL=emulator-5554 ./gradlew connectedDebugAndroidTest`
- `ANDROID_SERIAL=emulator-5556 ./gradlew verifyDebugCoverage`

## Review
- Code-reviewer sub-agent: APPROVED

Refs #55
Closes #62