### PR TITLE
Phase 1: make manual sync non-blocking

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTopBarTest.kt
@@ -13,7 +13,10 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jhow.shopplist.domain.icon.IconBucket
 import com.jhow.shopplist.domain.icon.IconMatcher
+import com.jhow.shopplist.domain.model.ShoppingItem
+import com.jhow.shopplist.domain.model.SyncStatus
 import com.jhow.shopplist.presentation.icon.IconResolver
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -133,18 +136,33 @@ class ShoppingListTopBarTest {
     }
 
     @Test
-    fun syncBadgeSpinner_visible_whenManualSyncTrue() {
+    fun manualSync_showsTopLinearProgress_withoutBlockingListInteraction() {
+        var clickedItemId: String? = null
+
         composeRule.setContent {
             ShoppingListScreen(
-                uiState = ShoppingListUiState(isSyncConfigured = true, isManualSync = true),
+                uiState = ShoppingListUiState(
+                    isSyncConfigured = true,
+                    isManualSync = true,
+                    pendingItems = listOf(sampleItem(id = "milk", name = "Milk"))
+                ),
                 snackbarHostState = SnackbarHostState(),
+                itemCallbacks = ShoppingListItemCallbacks(
+                    onPendingItemClick = { clickedItemId = it }
+                ),
                 iconResolver = fakeIconResolver
             )
         }
         composeRule.waitForIdle()
 
         composeRule.onNodeWithTag(ShoppingListTestTags.SYNC_BADGE_SPINNER).assertIsDisplayed()
-        composeRule.onNodeWithTag(ShoppingListTestTags.MANUAL_SYNC_LOADER).assertIsDisplayed()
+        composeRule.onNodeWithTag(ShoppingListTestTags.MANUAL_SYNC_PROGRESS_INDICATOR).assertIsDisplayed()
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.MANUAL_SYNC_LOADER).assertCountEquals(0)
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("milk")).performClick()
+        composeRule.waitForIdle()
+
+        assertEquals("milk", clickedItemId)
     }
 
     @Test
@@ -160,7 +178,7 @@ class ShoppingListTopBarTest {
 
         composeRule.onNodeWithTag(ShoppingListTestTags.SYNC_BADGE_SPINNER).assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Sync now").assertIsDisplayed()
-        composeRule.onAllNodesWithTag(ShoppingListTestTags.MANUAL_SYNC_LOADER).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(ShoppingListTestTags.MANUAL_SYNC_PROGRESS_INDICATOR).assertCountEquals(0)
     }
 
     @Test
@@ -183,4 +201,15 @@ class ShoppingListTopBarTest {
         composeRule.onNodeWithText("2").assertIsDisplayed()
         composeRule.onAllNodesWithTag(ShoppingListTestTags.SYNC_SETTINGS_BUTTON).assertCountEquals(0)
     }
+
+    private fun sampleItem(id: String, name: String): ShoppingItem = ShoppingItem(
+        id = id,
+        name = name,
+        isPurchased = false,
+        purchaseCount = 0,
+        createdAt = 0L,
+        updatedAt = 0L,
+        isDeleted = false,
+        syncStatus = SyncStatus.SYNCED
+    )
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -62,12 +62,15 @@ import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -81,6 +84,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -134,7 +138,8 @@ private data class ShoppingItemRowInteractions(
 )
 
 private data class ShoppingListContentLayout(
-    val innerPadding: PaddingValues
+    val innerPadding: PaddingValues,
+    val inputBarHeight: Dp
 )
 
 internal fun shoppingListBottomContentPadding(inputBarHeight: Dp): Dp = inputBarHeight
@@ -235,6 +240,8 @@ fun ShoppingListScreen(
     iconResolver: IconResolver
 ) {
     val focusManager = LocalFocusManager.current
+    var inputBarContentHeightPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
 
     LaunchedEffect(Unit) {
         focusManager.clearFocus(force = true)
@@ -267,10 +274,14 @@ fun ShoppingListScreen(
         ShoppingListScreenContent(
             uiState = uiState,
             layout = ShoppingListContentLayout(
-                innerPadding = innerPadding
+                innerPadding = innerPadding,
+                inputBarHeight = with(density) {
+                    if (inputBarContentHeightPx > 0) inputBarContentHeightPx.toDp() else 0.dp
+                }
             ),
             inputCallbacks = inputCallbacks,
             itemCallbacks = itemCallbacks,
+            onInputBarHeightChanged = { inputBarContentHeightPx = it },
             iconResolver = iconResolver
         )
     }
@@ -283,6 +294,7 @@ private fun ShoppingListScreenContent(
     layout: ShoppingListContentLayout,
     inputCallbacks: ShoppingListInputCallbacks,
     itemCallbacks: ShoppingListItemCallbacks,
+    onInputBarHeightChanged: (Int) -> Unit,
     iconResolver: IconResolver
 ) {
     Box(
@@ -301,6 +313,7 @@ private fun ShoppingListScreenContent(
             value = uiState.inputValue,
             suggestions = uiState.suggestions,
             inputCallbacks = inputCallbacks,
+            onContentHeightChanged = onInputBarHeightChanged,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
     }
@@ -467,6 +480,7 @@ private fun ShoppingInputBar(
     value: String,
     suggestions: List<String>,
     inputCallbacks: ShoppingListInputCallbacks,
+    onContentHeightChanged: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -487,6 +501,7 @@ private fun ShoppingInputBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
+                .onSizeChanged { onContentHeightChanged(it.height) }
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             ShoppingInputField(

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.imePadding
@@ -45,6 +46,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHost
@@ -60,7 +62,6 @@ import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -68,7 +69,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -81,8 +81,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -136,8 +134,7 @@ private data class ShoppingItemRowInteractions(
 )
 
 private data class ShoppingListContentLayout(
-    val innerPadding: PaddingValues,
-    val inputBarHeight: Dp
+    val innerPadding: PaddingValues
 )
 
 internal fun shoppingListBottomContentPadding(inputBarHeight: Dp): Dp = inputBarHeight
@@ -238,8 +235,6 @@ fun ShoppingListScreen(
     iconResolver: IconResolver
 ) {
     val focusManager = LocalFocusManager.current
-    var inputBarContentHeightPx by remember { mutableIntStateOf(0) }
-    val density = LocalDensity.current
 
     LaunchedEffect(Unit) {
         focusManager.clearFocus(force = true)
@@ -251,25 +246,31 @@ fun ShoppingListScreen(
             .testTag(ShoppingListTestTags.SCREEN),
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
-            ShoppingListTopAppBar(
-                uiState = uiState,
-                itemCallbacks = itemCallbacks,
-                syncCallbacks = syncCallbacks
-            )
+            Column {
+                ShoppingListTopAppBar(
+                    uiState = uiState,
+                    itemCallbacks = itemCallbacks,
+                    syncCallbacks = syncCallbacks
+                )
+                if (uiState.isManualSync) {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(2.dp)
+                            .testTag(ShoppingListTestTags.MANUAL_SYNC_PROGRESS_INDICATOR)
+                    )
+                }
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { innerPadding ->
         ShoppingListScreenContent(
             uiState = uiState,
             layout = ShoppingListContentLayout(
-                innerPadding = innerPadding,
-                inputBarHeight = with(density) {
-                    if (inputBarContentHeightPx > 0) inputBarContentHeightPx.toDp() else 0.dp
-                }
+                innerPadding = innerPadding
             ),
             inputCallbacks = inputCallbacks,
             itemCallbacks = itemCallbacks,
-            onInputBarHeightChanged = { inputBarContentHeightPx = it },
             iconResolver = iconResolver
         )
     }
@@ -282,7 +283,6 @@ private fun ShoppingListScreenContent(
     layout: ShoppingListContentLayout,
     inputCallbacks: ShoppingListInputCallbacks,
     itemCallbacks: ShoppingListItemCallbacks,
-    onInputBarHeightChanged: (Int) -> Unit,
     iconResolver: IconResolver
 ) {
     Box(
@@ -297,22 +297,10 @@ private fun ShoppingListScreenContent(
             iconResolver = iconResolver,
             bottomContentPadding = shoppingListBottomContentPadding(layout.inputBarHeight)
         )
-
-        if (uiState.isManualSync) {
-            CircularProgressIndicator(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(bottom = layout.inputBarHeight)
-                    .size(48.dp)
-                    .testTag(ShoppingListTestTags.MANUAL_SYNC_LOADER)
-            )
-        }
-
         ShoppingInputBar(
             value = uiState.inputValue,
             suggestions = uiState.suggestions,
             inputCallbacks = inputCallbacks,
-            onContentHeightChanged = onInputBarHeightChanged,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
     }
@@ -479,7 +467,6 @@ private fun ShoppingInputBar(
     value: String,
     suggestions: List<String>,
     inputCallbacks: ShoppingListInputCallbacks,
-    onContentHeightChanged: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -500,7 +487,6 @@ private fun ShoppingInputBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
-                .onSizeChanged { onContentHeightChanged(it.height) }
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             ShoppingInputField(

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListTestTags.kt
@@ -14,6 +14,7 @@ object ShoppingListTestTags {
     const val SYNC_BADGE = "sync_badge"
     const val SYNC_BADGE_SPINNER = "sync_badge_spinner"
     const val MANUAL_SYNC_LOADER = "manual_sync_loader"
+    const val MANUAL_SYNC_PROGRESS_INDICATOR = "manual_sync_progress_indicator"
     const val SYNC_SETTINGS_BUTTON = "sync_settings_button"
     const val SYNC_SETTINGS_SHEET = "sync_settings_sheet"
     const val SYNC_SERVER_FIELD = "sync_server_field"


### PR DESCRIPTION
## Summary

Implements #63 from PRD #55.

- Replaces the centered blocking manual-sync loader with a 2dp `LinearProgressIndicator` directly under the top app bar.
- Keeps the existing top-app-bar spinner for manual/background sync state.
- Leaves the shopping list content interactive while manual sync is in flight.
- Removes stale input-bar height measurement plumbing that only supported the deleted centered overlay.

## Verification

- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `./gradlew connectedDebugAndroidTest`
- `./gradlew verifyDebugCoverage`

Reviewed by `@code-reviewer`: APPROVED.

Closes #63
Refs #55