### PR TITLE
ci: speed up Android validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -33,11 +37,10 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
+      - name: Validate pull request
+        if: github.event_name == 'pull_request'
+        run: ./gradlew --continue testDebugUnitTest lintDebug assembleDebug
 
-      - name: Run lint
-        run: ./gradlew lintDebug lintRelease
-
-      - name: Build debug and release APKs
-        run: ./gradlew assembleDebug assembleRelease
+      - name: Validate main branch
+        if: github.event_name == 'push'
+        run: ./gradlew --continue testDebugUnitTest lintDebug lintRelease assembleDebug assembleRelease

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,19 +186,29 @@ tasks.matching { task -> task.name in signingRequiredTaskNames }
     }
 
 tasks.matching { task -> task.name == "assembleRelease" }.configureEach {
-    doFirst {
-        if (requireReleaseSigning) {
-            check(hasReleaseSigningConfig) { releaseSigningMissingMessage }
+    val isReleaseSigningConfigured = hasReleaseSigningConfig
+    val shouldRequireReleaseSigning = requireReleaseSigning
+    val missingSigningMessage = releaseSigningMissingMessage
+
+    doFirst(
+        "validateReleaseSigning",
+        org.gradle.api.Action<org.gradle.api.Task> {
+            if (shouldRequireReleaseSigning) {
+                check(isReleaseSigningConfigured) { missingSigningMessage }
+            }
         }
-    }
-    doLast {
-        if (!hasReleaseSigningConfig && !requireReleaseSigning) {
-            logger.warn(
-                "assembleRelease completed without release signing. " +
-                    "The generated release APK is unsigned and must not be distributed."
-            )
+    )
+    doLast(
+        "warnUnsignedRelease",
+        org.gradle.api.Action<org.gradle.api.Task> {
+            if (!isReleaseSigningConfigured && !shouldRequireReleaseSigning) {
+                println(
+                    "assembleRelease completed without release signing. " +
+                        "The generated release APK is unsigned and must not be distributed."
+                )
+            }
         }
-    }
+    )
 }
 
 jacoco {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 android.useAndroidX=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit


### PR DESCRIPTION
## Summary
- add CI concurrency cancellation for superseded runs
- make pull-request validation run only debug test/lint/build work
- keep release lint/build validation on main pushes
- enable Gradle build and configuration caches
- make the unsigned release signing notice compatible with Gradle configuration cache

## Local validation
- `./gradlew --continue testDebugUnitTest lintDebug assembleDebug`
- `./gradlew --configuration-cache --continue testDebugUnitTest lintDebug assembleDebug`
- `./gradlew --continue testDebugUnitTest lintDebug lintRelease assembleDebug assembleRelease`