### PR TITLE
Phase 1: Snackbar undo for delete

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -373,44 +373,36 @@ class ShoppingListScreenTest {
     }
 
     @Test
-    fun swipingPendingItemAndConfirmingRemovesItFromVisibleLists() {
+    fun swipingPendingItemRemovesItAndShowsUndoSnackbar() {
         composeRule.onNodeWithTag(ShoppingListTestTags.swipePendingItem("pending-apples")).performTouchInput {
             swipeLeft()
         }
         composeRule.waitForIdle()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithText("Item deleted").fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-apples")).fetchSemanticsNodes().isEmpty()
         }
 
-        composeRule.onNodeWithText("Delete").performClick()
-        composeRule.waitForIdle()
-
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-apples")).fetchSemanticsNodes().isEmpty()
-        }
-
+        assertTrue(composeRule.onAllNodesWithText("Undo").fetchSemanticsNodes().isNotEmpty())
         assertTrue(
             composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-apples")).fetchSemanticsNodes().isEmpty()
+        )
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isEmpty()
         )
     }
 
     @Test
-    fun swipingPurchasedItemAndConfirmingRemovesItFromHistory() {
+    fun swipingPurchasedItemRemovesItAndShowsUndoSnackbar() {
         composeRule.onNodeWithTag(ShoppingListTestTags.swipePurchasedItem("purchased-coffee")).performTouchInput {
             swipeLeft()
         }
         composeRule.waitForIdle()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isNotEmpty()
-        }
-
-        composeRule.onNodeWithText("Delete").performClick()
-        composeRule.waitForIdle()
-
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).fetchSemanticsNodes().isEmpty()
+            composeRule.onAllNodesWithText("Item deleted").fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).fetchSemanticsNodes().isEmpty()
         }
 
         assertTrue(
@@ -419,7 +411,7 @@ class ShoppingListScreenTest {
     }
 
     @Test
-    fun swipingPendingItemAndCancellingKeepsItVisible() {
+    fun swipingPendingItemAndTappingUndoRestoresIt() {
         val initialLeft = composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-bread"))
             .fetchSemanticsNode().boundsInRoot.left
 
@@ -429,14 +421,14 @@ class ShoppingListScreenTest {
         composeRule.waitForIdle()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithText("Item deleted").fetchSemanticsNodes().isNotEmpty()
         }
 
-        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.onNodeWithText("Undo").performClick()
         composeRule.waitForIdle()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithTag(ShoppingListTestTags.DELETE_ITEM_DIALOG).fetchSemanticsNodes().isEmpty()
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-bread")).fetchSemanticsNodes().isNotEmpty()
         }
 
         composeRule.waitForIdle()
@@ -449,6 +441,29 @@ class ShoppingListScreenTest {
             composeRule.onAllNodesWithTag(ShoppingListTestTags.pendingItem("pending-bread")).fetchSemanticsNodes().isNotEmpty()
         )
         assertTrue(abs(restoredLeft - initialLeft) <= tolerance)
+    }
+
+    @Test
+    fun deletingMultipleItemsCoalescesUndoSnackbar() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.swipePendingItem("pending-apples")).performTouchInput {
+            swipeLeft()
+        }
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Item deleted").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag(ShoppingListTestTags.swipePendingItem("pending-bread")).performTouchInput {
+            swipeLeft()
+        }
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("2 items deleted").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(composeRule.onAllNodesWithText("Undo").fetchSemanticsNodes().isNotEmpty())
     }
 
 

--- a/app/src/main/java/com/jhow/shopplist/data/repository/ShoppingListRepositoryImpl.kt
+++ b/app/src/main/java/com/jhow/shopplist/data/repository/ShoppingListRepositoryImpl.kt
@@ -79,6 +79,12 @@ class ShoppingListRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun restoreDeletedItem(item: ShoppingItem) {
+        withContext(ioDispatcher) {
+            shoppingItemDao.insertItem(item.toEntity())
+        }
+    }
+
     override suspend fun getPendingSyncItems(): List<ShoppingItem> = withContext(ioDispatcher) {
         shoppingItemDao.getPendingSyncItems().map { it.toDomain() }
     }
@@ -154,4 +160,20 @@ class ShoppingListRepositoryImpl @Inject constructor(
 
     private fun ShoppingItemEntity.updatedPurchaseCount(isCompletedRemotely: Boolean): Int =
         if (isCompletedRemotely && !isPurchased) purchaseCount + 1 else purchaseCount
+
+    private fun ShoppingItem.toEntity(): ShoppingItemEntity = ShoppingItemEntity(
+        id = id,
+        name = name,
+        isPurchased = isPurchased,
+        purchaseCount = purchaseCount,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        isDeleted = isDeleted,
+        syncStatus = syncStatus,
+        remoteUid = remoteMetadata.remoteUid,
+        remoteHref = remoteMetadata.remoteHref,
+        remoteEtag = remoteMetadata.remoteEtag,
+        remoteLastModifiedAt = remoteMetadata.remoteLastModifiedAt,
+        lastSyncedAt = remoteMetadata.lastSyncedAt
+    )
 }

--- a/app/src/main/java/com/jhow/shopplist/domain/repository/ShoppingListRepository.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/repository/ShoppingListRepository.kt
@@ -25,6 +25,8 @@ interface ShoppingListRepository {
 
     suspend fun softDeleteItem(id: String)
 
+    suspend fun restoreDeletedItem(item: ShoppingItem)
+
     suspend fun getPendingSyncItems(): List<ShoppingItem>
 
     suspend fun getAllItems(): List<ShoppingItem>

--- a/app/src/main/java/com/jhow/shopplist/domain/usecase/RestoreDeletedShoppingItemUseCase.kt
+++ b/app/src/main/java/com/jhow/shopplist/domain/usecase/RestoreDeletedShoppingItemUseCase.kt
@@ -1,0 +1,13 @@
+package com.jhow.shopplist.domain.usecase
+
+import com.jhow.shopplist.domain.model.ShoppingItem
+import com.jhow.shopplist.domain.repository.ShoppingListRepository
+import javax.inject.Inject
+
+class RestoreDeletedShoppingItemUseCase @Inject constructor(
+    private val repository: ShoppingListRepository
+) {
+    suspend operator fun invoke(item: ShoppingItem) {
+        repository.restoreDeletedItem(item)
+    }
+}

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.ShoppingBag
 import androidx.compose.material.icons.rounded.Sync
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -51,7 +50,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
@@ -74,6 +74,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -106,8 +107,7 @@ class ShoppingListItemCallbacks(
     val onDeleteSelectedItems: () -> Unit = {},
     val onSelectionModeExited: () -> Unit = {},
     val onDeleteItemRequested: (ShoppingItem) -> Unit = {},
-    val onDeleteItemDismissed: () -> Unit = {},
-    val onDeleteItemConfirmed: () -> Unit = {}
+    val onDeleteUndoRequested: () -> Unit = {}
 )
 
 class ShoppingListSyncCallbacks(
@@ -208,8 +208,7 @@ fun ShoppingListRoute(
             onDeleteSelectedItems = viewModel::onDeleteSelectedItems,
             onSelectionModeExited = viewModel::onSelectionModeExited,
             onDeleteItemRequested = viewModel::onDeleteItemRequested,
-            onDeleteItemDismissed = viewModel::onDeleteItemDismissed,
-            onDeleteItemConfirmed = viewModel::onDeleteItemConfirmed
+            onDeleteUndoRequested = viewModel::onDeleteUndoRequested
         )
     }
     val syncCallbacks = remember(viewModel) {
@@ -246,6 +245,11 @@ fun ShoppingListScreen(
     LaunchedEffect(Unit) {
         focusManager.clearFocus(force = true)
     }
+    DeleteUndoSnackbarEffect(
+        snackbarState = uiState.deleteUndoSnackbar,
+        snackbarHostState = snackbarHostState,
+        onUndo = itemCallbacks.onDeleteUndoRequested
+    )
 
     Scaffold(
         modifier = modifier
@@ -287,6 +291,40 @@ fun ShoppingListScreen(
     }
 }
 
+@Composable
+private fun DeleteUndoSnackbarEffect(
+    snackbarState: DeleteUndoSnackbarState?,
+    snackbarHostState: SnackbarHostState,
+    onUndo: () -> Unit
+) {
+    val message = when {
+        snackbarState == null -> ""
+        snackbarState.count == 1 -> stringResource(R.string.delete_item_snackbar_single)
+        else -> pluralStringResource(
+            R.plurals.delete_item_snackbar_multiple,
+            snackbarState.count,
+            snackbarState.count
+        )
+    }
+    val undoLabel = stringResource(R.string.delete_item_undo)
+
+    LaunchedEffect(snackbarState) {
+        if (snackbarState == null) {
+            snackbarHostState.currentSnackbarData?.dismiss()
+            return@LaunchedEffect
+        }
+
+        val result = snackbarHostState.showSnackbar(
+            message = message,
+            actionLabel = undoLabel,
+            duration = SnackbarDuration.Indefinite
+        )
+        if (result == SnackbarResult.ActionPerformed) {
+            onUndo()
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ShoppingListScreenContent(
@@ -318,11 +356,6 @@ private fun ShoppingListScreenContent(
         )
     }
 
-    DeleteItemDialog(
-        item = uiState.itemPendingDeletion,
-        onDismiss = itemCallbacks.onDeleteItemDismissed,
-        onConfirm = itemCallbacks.onDeleteItemConfirmed
-    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -618,7 +651,7 @@ private fun ShoppingItemsContent(
     iconResolver: IconResolver,
     bottomContentPadding: Dp
 ) {
-    val swipeResetTrigger = uiState.itemPendingDeletion?.id.orEmpty()
+    val swipeResetTrigger = uiState.deleteUndoSnackbar?.count?.toString().orEmpty()
     val emptyPendingTitle = stringResource(R.string.empty_pending_title)
     val emptyPurchasedTitle = stringResource(R.string.empty_purchased_title)
 
@@ -732,32 +765,6 @@ private fun androidx.compose.foundation.lazy.LazyListScope.purchasedItemsSection
             modifier = Modifier.animateItem()
         )
     }
-}
-
-@Composable
-private fun DeleteItemDialog(
-    item: ShoppingItem?,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit
-) {
-    if (item == null) return
-
-    AlertDialog(
-        modifier = Modifier.testTag(ShoppingListTestTags.DELETE_ITEM_DIALOG),
-        onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.delete_item_title)) },
-        text = { Text(text = stringResource(R.string.delete_item_message, item.name)) },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(text = stringResource(R.string.delete_item_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(R.string.delete_item_cancel))
-            }
-        }
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiState.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListUiState.kt
@@ -11,7 +11,7 @@ data class ShoppingListUiState(
     val purchasedItems: List<ShoppingItem> = emptyList(),
     val selectedIds: Set<String> = emptySet(),
     val isSelectionMode: Boolean = false,
-    val itemPendingDeletion: ShoppingItem? = null,
+    val deleteUndoSnackbar: DeleteUndoSnackbarState? = null,
     val isManualSync: Boolean = false,
     val isBackgroundSync: Boolean = false,
     val isSyncConfigured: Boolean = false

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModel.kt
@@ -14,8 +14,10 @@ import com.jhow.shopplist.domain.usecase.ObservePendingItemsUseCase
 import com.jhow.shopplist.domain.usecase.ObservePurchasedItemsUseCase
 import com.jhow.shopplist.domain.usecase.ObserveSyncStateUseCase
 import com.jhow.shopplist.domain.usecase.RequestShoppingSyncUseCase
+import com.jhow.shopplist.domain.usecase.RestoreDeletedShoppingItemUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +38,7 @@ private data class ShoppingListIntermediateState(
     val currentSuggestions: List<String>,
     val selectedIds: Set<String>,
     val isSelectionMode: Boolean,
-    val itemPendingDeletion: ShoppingItem?
+    val deleteUndoSnackbar: DeleteUndoSnackbarState?
 )
 
 @HiltViewModel
@@ -47,6 +49,7 @@ class ShoppingListViewModel @Inject constructor(
     observeItemNamesUseCase: ObserveItemNamesUseCase,
     private val addOrReclaimShoppingItemUseCase: AddOrReclaimShoppingItemUseCase,
     private val deleteShoppingItemUseCase: DeleteShoppingItemUseCase,
+    private val restoreDeletedShoppingItemUseCase: RestoreDeletedShoppingItemUseCase,
     private val markSelectedItemsPurchasedUseCase: MarkSelectedItemsPurchasedUseCase,
     private val markPurchasedItemPendingUseCase: MarkPurchasedItemPendingUseCase,
     private val requestShoppingSyncUseCase: RequestShoppingSyncUseCase,
@@ -55,7 +58,23 @@ class ShoppingListViewModel @Inject constructor(
     private val selectionController: SelectionController
 ) : ViewModel() {
     private val inputValue = MutableStateFlow("")
-    private val itemPendingDeletion = MutableStateFlow<ShoppingItem?>(null)
+    private val undoCoordinator = UndoCoordinator(
+        timeoutMillis = DELETE_UNDO_TIMEOUT_MILLIS,
+        scope = viewModelScope,
+        dispatcher = Dispatchers.Main.immediate,
+        onOptimisticDelete = { item ->
+            deleteShoppingItemUseCase(item.id)
+            if (item.id in selectionController.selected.value) {
+                selectionController.toggle(item.id)
+            }
+        },
+        onRestore = { item ->
+            restoreDeletedShoppingItemUseCase(item)
+        },
+        onCommit = {
+            requestSync()
+        }
+    )
     private val inputWithSuggestions = combine(observeItemNamesUseCase(), inputValue) { allItemNames, currentInput ->
         currentInput to buildSuggestions(allItemNames = allItemNames, currentInput = currentInput)
     }
@@ -64,14 +83,14 @@ class ShoppingListViewModel @Inject constructor(
         inputWithSuggestions,
         selectionController.selected,
         selectionController.isActive,
-        itemPendingDeletion
-    ) { inputSuggestions, selectedIds, isSelectionMode, pendingDeletion ->
+        undoCoordinator.snackbarState
+    ) { inputSuggestions, selectedIds, isSelectionMode, deleteUndoSnackbar ->
         ViewSignals(
             currentInput = inputSuggestions.first,
             currentSuggestions = inputSuggestions.second,
             selectedIds = selectedIds,
             isSelectionMode = isSelectionMode,
-            itemPendingDeletion = pendingDeletion
+            deleteUndoSnackbar = deleteUndoSnackbar
         )
     }
 
@@ -87,7 +106,7 @@ class ShoppingListViewModel @Inject constructor(
             currentSuggestions = signals.currentSuggestions,
             selectedIds = signals.selectedIds,
             isSelectionMode = signals.isSelectionMode,
-            itemPendingDeletion = signals.itemPendingDeletion
+            deleteUndoSnackbar = signals.deleteUndoSnackbar
         )
     }
 
@@ -125,7 +144,6 @@ class ShoppingListViewModel @Inject constructor(
         .combine(isSyncConfigured) { (intermediate, syncing, latch), configured ->
             val pendingIds = intermediate.pendingItems.mapTo(linkedSetOf()) { it.id }
             val distinctPurchasedItems = intermediate.purchasedItems.filterNot { it.id in pendingIds }
-            val visibleItems = intermediate.pendingItems + distinctPurchasedItems
             val visibleSelectedIds = intermediate.selectedIds.intersect(pendingIds)
 
             if (visibleSelectedIds != intermediate.selectedIds) {
@@ -139,7 +157,7 @@ class ShoppingListViewModel @Inject constructor(
                 purchasedItems = distinctPurchasedItems,
                 selectedIds = visibleSelectedIds,
                 isSelectionMode = intermediate.isSelectionMode && visibleSelectedIds.isNotEmpty(),
-                itemPendingDeletion = visibleItems.firstOrNull { it.id == intermediate.itemPendingDeletion?.id },
+                deleteUndoSnackbar = intermediate.deleteUndoSnackbar,
                 isManualSync = syncing && latch,
                 isBackgroundSync = syncing && !latch,
                 isSyncConfigured = configured
@@ -225,24 +243,11 @@ class ShoppingListViewModel @Inject constructor(
     }
 
     fun onDeleteItemRequested(item: ShoppingItem) {
-        itemPendingDeletion.value = item
+        undoCoordinator.onDelete(item)
     }
 
-    fun onDeleteItemDismissed() {
-        itemPendingDeletion.value = null
-    }
-
-    fun onDeleteItemConfirmed() {
-        val item = itemPendingDeletion.value ?: return
-
-        viewModelScope.launch {
-            deleteShoppingItemUseCase(item.id)
-            if (item.id in selectionController.selected.value) {
-                selectionController.toggle(item.id)
-            }
-            itemPendingDeletion.value = null
-            requestSync()
-        }
+    fun onDeleteUndoRequested() {
+        undoCoordinator.onUndo()
     }
 
     fun onManualSyncRequested() {
@@ -262,6 +267,7 @@ class ShoppingListViewModel @Inject constructor(
     private companion object {
         const val MIN_SUGGESTION_QUERY_LENGTH = 2
         const val MAX_SUGGESTION_COUNT = 5
+        const val DELETE_UNDO_TIMEOUT_MILLIS = 4_000L
 
         fun buildSuggestions(allItemNames: List<String>, currentInput: String): List<String> {
             val normalizedInput = ShoppingSearch.normalize(currentInput)
@@ -301,6 +307,6 @@ class ShoppingListViewModel @Inject constructor(
         val currentSuggestions: List<String>,
         val selectedIds: Set<String>,
         val isSelectionMode: Boolean,
-        val itemPendingDeletion: ShoppingItem?
+        val deleteUndoSnackbar: DeleteUndoSnackbarState?
     )
 }

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/UndoCoordinator.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/UndoCoordinator.kt
@@ -1,0 +1,66 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+import com.jhow.shopplist.domain.model.ShoppingItem
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class DeleteUndoSnackbarState(
+    val count: Int
+)
+
+class UndoCoordinator(
+    private val timeoutMillis: Long,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+    private val onOptimisticDelete: suspend (ShoppingItem) -> Unit,
+    private val onRestore: suspend (ShoppingItem) -> Unit,
+    private val onCommit: suspend (List<ShoppingItem>) -> Unit
+) {
+    private val pendingItems = mutableListOf<ShoppingItem>()
+    private var timeoutJob: Job? = null
+    private val mutableSnackbarState = MutableStateFlow<DeleteUndoSnackbarState?>(null)
+
+    val snackbarState: StateFlow<DeleteUndoSnackbarState?> = mutableSnackbarState.asStateFlow()
+
+    fun onDelete(item: ShoppingItem) {
+        scope.launch(dispatcher) {
+            onOptimisticDelete(item)
+            pendingItems += item
+            mutableSnackbarState.value = DeleteUndoSnackbarState(count = pendingItems.size)
+            restartTimeout()
+        }
+    }
+
+    fun onUndo() {
+        scope.launch(dispatcher) {
+            timeoutJob?.cancel()
+            val itemsToRestore = pendingItems.toList()
+            pendingItems.clear()
+            mutableSnackbarState.value = null
+            itemsToRestore.forEach { item -> onRestore(item) }
+        }
+    }
+
+    private fun restartTimeout() {
+        timeoutJob?.cancel()
+        timeoutJob = scope.launch(dispatcher) {
+            delay(timeoutMillis)
+            commitPendingItems()
+        }
+    }
+
+    private suspend fun commitPendingItems() {
+        val itemsToCommit = pendingItems.toList()
+        pendingItems.clear()
+        mutableSnackbarState.value = null
+        if (itemsToCommit.isNotEmpty()) {
+            onCommit(itemsToCommit)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,11 +11,13 @@
     <string name="purchased_items_title">Purchased history</string>
     <string name="empty_pending_title">Nothing pending yet</string>
     <string name="empty_purchased_title">No purchase history</string>
-    <string name="delete_item_title">Delete item</string>
-    <string name="delete_item_message">Remove %1$s from the local list and queue the deletion for sync?</string>
     <string name="delete_item_swipe_label">Delete item</string>
-    <string name="delete_item_confirm">Delete</string>
-    <string name="delete_item_cancel">Cancel</string>
+    <string name="delete_item_snackbar_single">Item deleted</string>
+    <string name="delete_item_undo">Undo</string>
+    <plurals name="delete_item_snackbar_multiple">
+        <item quantity="one">%1$d item deleted</item>
+        <item quantity="other">%1$d items deleted</item>
+    </plurals>
     <string name="sync_now">Sync now</string>
     <string name="sync_settings">Sync settings</string>
     <string name="sync_server_label">Server</string>

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListViewModelTest.kt
@@ -13,12 +13,15 @@ import com.jhow.shopplist.domain.usecase.ObservePendingItemsUseCase
 import com.jhow.shopplist.domain.usecase.ObservePurchasedItemsUseCase
 import com.jhow.shopplist.domain.usecase.ObserveSyncStateUseCase
 import com.jhow.shopplist.domain.usecase.RequestShoppingSyncUseCase
+import com.jhow.shopplist.domain.usecase.RestoreDeletedShoppingItemUseCase
 import com.jhow.shopplist.testing.FakeCalDavConfigRepository
 import com.jhow.shopplist.testing.FakeShoppingListRepository
 import com.jhow.shopplist.testing.FakeShoppingSyncScheduler
 import com.jhow.shopplist.testing.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -50,6 +53,7 @@ class ShoppingListViewModelTest {
             observeItemNamesUseCase = ObserveItemNamesUseCase(repository),
             addOrReclaimShoppingItemUseCase = AddOrReclaimShoppingItemUseCase(repository),
             deleteShoppingItemUseCase = DeleteShoppingItemUseCase(repository),
+            restoreDeletedShoppingItemUseCase = RestoreDeletedShoppingItemUseCase(repository),
             markSelectedItemsPurchasedUseCase = MarkSelectedItemsPurchasedUseCase(repository),
             markPurchasedItemPendingUseCase = MarkPurchasedItemPendingUseCase(repository),
             requestShoppingSyncUseCase = RequestShoppingSyncUseCase(syncScheduler),
@@ -378,26 +382,41 @@ class ShoppingListViewModelTest {
         advanceUntilIdle()
 
         viewModel.onDeleteItemRequested(samplePendingItem(id = "tomatoes"))
-        advanceUntilIdle()
-        assertEquals("tomatoes", viewModel.uiState.value.itemPendingDeletion?.id)
-
-        viewModel.onDeleteItemConfirmed()
-        advanceUntilIdle()
+        runCurrent()
 
         assertEquals(listOf("tomatoes"), repository.deletedRequests)
-        assertEquals(null, viewModel.uiState.value.itemPendingDeletion)
+        assertEquals(DeleteUndoSnackbarState(count = 1), viewModel.uiState.value.deleteUndoSnackbar)
+        assertEquals(0, syncScheduler.requestCount)
+    }
+
+    @Test
+    fun `delete timeout commits deletion and requests sync`() = runTest {
+        repository.seedItems(listOf(samplePendingItem(id = "tomatoes")))
+        advanceUntilIdle()
+
+        viewModel.onDeleteItemRequested(samplePendingItem(id = "tomatoes"))
+        runCurrent()
+        advanceTimeBy(4_000)
+        runCurrent()
+
+        assertEquals(null, viewModel.uiState.value.deleteUndoSnackbar)
         assertEquals(1, syncScheduler.requestCount)
     }
 
     @Test
-    fun `delete dismissal clears pending deletion item`() = runTest {
+    fun `delete undo restores item without requesting sync`() = runTest {
         repository.seedItems(listOf(samplePurchasedItem(id = "olive-oil")))
         advanceUntilIdle()
 
         viewModel.onDeleteItemRequested(samplePurchasedItem(id = "olive-oil"))
-        viewModel.onDeleteItemDismissed()
+        runCurrent()
 
-        assertEquals(null, viewModel.uiState.value.itemPendingDeletion)
+        viewModel.onDeleteUndoRequested()
+        runCurrent()
+
+        assertEquals(listOf("olive-oil"), repository.restoredRequests)
+        assertEquals(null, viewModel.uiState.value.deleteUndoSnackbar)
+        assertEquals(0, syncScheduler.requestCount)
     }
 
     @Test

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/UndoCoordinatorTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/UndoCoordinatorTest.kt
@@ -1,0 +1,125 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+import com.jhow.shopplist.domain.model.ShoppingItem
+import com.jhow.shopplist.domain.model.SyncStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UndoCoordinatorTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val deletedItems = mutableListOf<ShoppingItem>()
+    private val restoredItems = mutableListOf<ShoppingItem>()
+    private val committedBatches = mutableListOf<List<ShoppingItem>>()
+
+    @Test
+    fun `single delete times out and commits`() = runTest(dispatcher) {
+        val coordinator = coordinator(backgroundScope)
+        val item = sampleItem(id = "milk")
+
+        coordinator.onDelete(item)
+        runCurrent()
+
+        assertEquals(listOf(item), deletedItems)
+        assertEquals(DeleteUndoSnackbarState(count = 1), coordinator.snackbarState.value)
+
+        advanceTimeBy(4_000)
+        runCurrent()
+
+        assertEquals(listOf(listOf(item)), committedBatches)
+        assertEquals(emptyList<ShoppingItem>(), restoredItems)
+        assertNull(coordinator.snackbarState.value)
+    }
+
+    @Test
+    fun `single delete undo restores item without committing`() = runTest(dispatcher) {
+        val coordinator = coordinator(backgroundScope)
+        val item = sampleItem(id = "bread")
+
+        coordinator.onDelete(item)
+        runCurrent()
+
+        coordinator.onUndo()
+        runCurrent()
+        advanceTimeBy(4_000)
+        runCurrent()
+
+        assertEquals(listOf(item), restoredItems)
+        assertEquals(emptyList<List<ShoppingItem>>(), committedBatches)
+        assertNull(coordinator.snackbarState.value)
+    }
+
+    @Test
+    fun `multiple deletes inside active window coalesce into one snackbar and commit batch`() = runTest(dispatcher) {
+        val coordinator = coordinator(backgroundScope)
+        val milk = sampleItem(id = "milk")
+        val bread = sampleItem(id = "bread")
+
+        coordinator.onDelete(milk)
+        runCurrent()
+        advanceTimeBy(2_000)
+        coordinator.onDelete(bread)
+        runCurrent()
+
+        assertEquals(listOf(milk, bread), deletedItems)
+        assertEquals(DeleteUndoSnackbarState(count = 2), coordinator.snackbarState.value)
+
+        advanceTimeBy(3_999)
+        runCurrent()
+        assertEquals(emptyList<List<ShoppingItem>>(), committedBatches)
+
+        advanceTimeBy(1)
+        runCurrent()
+
+        assertEquals(listOf(listOf(milk, bread)), committedBatches)
+        assertNull(coordinator.snackbarState.value)
+    }
+
+    @Test
+    fun `undo restores all coalesced deletes without committing`() = runTest(dispatcher) {
+        val coordinator = coordinator(backgroundScope)
+        val milk = sampleItem(id = "milk")
+        val bread = sampleItem(id = "bread")
+
+        coordinator.onDelete(milk)
+        runCurrent()
+        coordinator.onDelete(bread)
+        runCurrent()
+
+        coordinator.onUndo()
+        runCurrent()
+        advanceTimeBy(4_000)
+        runCurrent()
+
+        assertEquals(listOf(milk, bread), restoredItems)
+        assertEquals(emptyList<List<ShoppingItem>>(), committedBatches)
+        assertNull(coordinator.snackbarState.value)
+    }
+
+    private fun coordinator(scope: CoroutineScope): UndoCoordinator = UndoCoordinator(
+        timeoutMillis = 4_000,
+        scope = scope,
+        dispatcher = dispatcher,
+        onOptimisticDelete = { deletedItems += it },
+        onRestore = { restoredItems += it },
+        onCommit = { committedBatches += it }
+    )
+
+    private fun sampleItem(id: String): ShoppingItem = ShoppingItem(
+        id = id,
+        name = id.replaceFirstChar { it.uppercase() },
+        isPurchased = false,
+        purchaseCount = 1,
+        createdAt = 1L,
+        updatedAt = 2L,
+        isDeleted = false,
+        syncStatus = SyncStatus.SYNCED
+    )
+}

--- a/app/src/test/java/com/jhow/shopplist/testing/FakeShoppingListRepository.kt
+++ b/app/src/test/java/com/jhow/shopplist/testing/FakeShoppingListRepository.kt
@@ -18,6 +18,7 @@ class FakeShoppingListRepository : ShoppingListRepository {
     val purchasedRequests = mutableListOf<Set<String>>()
     val pendingRequests = mutableListOf<String>()
     val deletedRequests = mutableListOf<String>()
+    val restoredRequests = mutableListOf<String>()
     val remoteDeletedRequests = mutableListOf<String>()
     val syncedResults = mutableListOf<List<ShoppingItemSyncResult>>()
     val importedItems = mutableListOf<RemoteShoppingItemSnapshot>()
@@ -113,6 +114,11 @@ class FakeShoppingListRepository : ShoppingListRepository {
                 item
             }
         }
+    }
+
+    override suspend fun restoreDeletedItem(item: ShoppingItem) {
+        restoredRequests += item.id
+        items.value = items.value.filterNot { it.id == item.id } + item
     }
 
     override suspend fun getPendingSyncItems(): List<ShoppingItem> =


### PR DESCRIPTION
## Summary
- Replace swipe-delete confirmation dialog with immediate optimistic delete and snackbar undo
- Add standalone UndoCoordinator for 4-second timeout, coalescing, and restore/commit lifecycle
- Restore deleted items through a domain use case and update swipe-delete instrumentation coverage

## Links
- PRD: #55
- Closes #64

## Verification
- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- ANDROID_SERIAL=emulator-5554 ./gradlew verifyDebugCoverage

Code-reviewer sub-agent: APPROVED