### PR TITLE
Phase 1: Auto-collapse purchased section with counts

### DIFF
--- a/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
+++ b/app/src/androidTest/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreenTest.kt
@@ -66,6 +66,8 @@ class ShoppingListScreenTest {
         composeRule.onNodeWithTag(ShoppingListTestTags.pendingItem("pending-apples")).performClick()
         composeRule.waitForIdle()
 
+        expandPurchasedSection()
+
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-apples")).fetchSemanticsNodes().isNotEmpty()
         }
@@ -80,6 +82,8 @@ class ShoppingListScreenTest {
 
     @Test
     fun clickingPurchasedItemRestoresItToPendingSection() {
+        expandPurchasedSection()
+
         composeRule.onNodeWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).performClick()
         composeRule.waitForIdle()
 
@@ -95,6 +99,8 @@ class ShoppingListScreenTest {
     @Test
     fun shoppingRowsUseCompactSingleLineHeight() {
         composeRule.waitForIdle()
+        expandPurchasedSection()
+
         val maxCompactRowHeight = with(composeRule.density) { 64.dp.toPx() }
         val heightTolerance = with(composeRule.density) { 1.dp.toPx() }
 
@@ -154,10 +160,67 @@ class ShoppingListScreenTest {
         composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASE_SELECTED_BUTTON).performClick()
         composeRule.waitForIdle()
 
+        expandPurchasedSection()
+
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-apples")).fetchSemanticsNodes().isNotEmpty() &&
                 composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("pending-bread")).fetchSemanticsNodes().isNotEmpty()
         }
+    }
+
+    @Test
+    fun purchasedSectionIsCollapsedByDefaultWhenPendingItemsRemain() {
+        composeRule.waitForIdle()
+
+        assertTrue(composeRule.onAllNodesWithText("Pending items \u00b7 8").fetchSemanticsNodes().isNotEmpty())
+        assertTrue(composeRule.onAllNodesWithText("Purchased history \u00b7 2").fetchSemanticsNodes().isNotEmpty())
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).fetchSemanticsNodes().isEmpty()
+        )
+    }
+
+    @Test
+    fun tappingPurchasedSectionHeaderExpandsCollapsedRows() {
+        expandPurchasedSection()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-coffee")).fetchSemanticsNodes().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun purchasedSectionExpandsByDefaultWhenNothingIsPending() {
+        runBlocking {
+            database?.shoppingItemDao()?.replaceAll(
+                listOf(
+                    ShoppingItemEntity(
+                        id = "purchased-only",
+                        name = "Coffee",
+                        isPurchased = true,
+                        purchaseCount = 1,
+                        createdAt = 1L,
+                        updatedAt = 1L,
+                        isDeleted = false,
+                        syncStatus = SyncStatus.SYNCED
+                    )
+                )
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Pending items \u00b7 0").fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithText("Purchased history \u00b7 1").fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-only")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(
+            composeRule.onAllNodesWithTag(ShoppingListTestTags.purchasedItem("purchased-only")).fetchSemanticsNodes().isNotEmpty()
+        )
     }
 
     @Test
@@ -395,6 +458,8 @@ class ShoppingListScreenTest {
 
     @Test
     fun swipingPurchasedItemRemovesItAndShowsUndoSnackbar() {
+        expandPurchasedSection()
+
         composeRule.onNodeWithTag(ShoppingListTestTags.swipePurchasedItem("purchased-coffee")).performTouchInput {
             swipeLeft()
         }
@@ -464,6 +529,11 @@ class ShoppingListScreenTest {
         }
 
         assertTrue(composeRule.onAllNodesWithText("Undo").fetchSemanticsNodes().isNotEmpty())
+    }
+
+    private fun expandPurchasedSection() {
+        composeRule.onNodeWithTag(ShoppingListTestTags.PURCHASED_SECTION).performClick()
+        composeRule.waitForIdle()
     }
 
 

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/PurchasedSectionState.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/PurchasedSectionState.kt
@@ -1,0 +1,31 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+enum class PurchasedSectionVisibility {
+    Collapsed,
+    Expanded
+}
+
+object PurchasedSectionState {
+    fun resolve(
+        pendingCount: Int,
+        purchasedCount: Int,
+        userExpanded: Boolean?
+    ): PurchasedSectionVisibility {
+        require(pendingCount >= 0) { "pendingCount must not be negative" }
+        require(purchasedCount >= 0) { "purchasedCount must not be negative" }
+
+        userExpanded?.let { expanded ->
+            return if (expanded) {
+                PurchasedSectionVisibility.Expanded
+            } else {
+                PurchasedSectionVisibility.Collapsed
+            }
+        }
+
+        return if (pendingCount == 0) {
+            PurchasedSectionVisibility.Expanded
+        } else {
+            PurchasedSectionVisibility.Collapsed
+        }
+    }
+}

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/ShoppingListScreen.kt
@@ -63,8 +63,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -654,6 +656,13 @@ private fun ShoppingItemsContent(
     val swipeResetTrigger = uiState.deleteUndoSnackbar?.count?.toString().orEmpty()
     val emptyPendingTitle = stringResource(R.string.empty_pending_title)
     val emptyPurchasedTitle = stringResource(R.string.empty_purchased_title)
+    var userPurchasedSectionExpanded by rememberSaveable { mutableStateOf<Boolean?>(null) }
+    val purchasedSectionVisibility = PurchasedSectionState.resolve(
+        pendingCount = uiState.pendingItems.size,
+        purchasedCount = uiState.purchasedItems.size,
+        userExpanded = userPurchasedSectionExpanded
+    )
+    val isPurchasedSectionExpanded = purchasedSectionVisibility == PurchasedSectionVisibility.Expanded
 
     LazyColumn(
         modifier = modifier
@@ -664,7 +673,10 @@ private fun ShoppingItemsContent(
     ) {
         item(key = ShoppingListTestTags.PENDING_SECTION) {
             SectionHeader(
-                title = stringResource(R.string.pending_items_title),
+                title = sectionTitle(
+                    title = stringResource(R.string.pending_items_title),
+                    count = uiState.pendingItems.size
+                ),
                 modifier = Modifier.testTag(ShoppingListTestTags.PENDING_SECTION)
             )
         }
@@ -684,20 +696,31 @@ private fun ShoppingItemsContent(
 
         item(key = ShoppingListTestTags.PURCHASED_SECTION) {
             SectionHeader(
-                title = stringResource(R.string.purchased_items_title),
-                modifier = Modifier.testTag(ShoppingListTestTags.PURCHASED_SECTION)
+                title = sectionTitle(
+                    title = stringResource(R.string.purchased_items_title),
+                    count = uiState.purchasedItems.size
+                ),
+                modifier = Modifier
+                    .testTag(ShoppingListTestTags.PURCHASED_SECTION)
+                    .clickable {
+                        userPurchasedSectionExpanded = !isPurchasedSectionExpanded
+                    }
             )
         }
 
-        purchasedItemsSection(
-            purchasedItems = uiState.purchasedItems,
-            swipeResetTrigger = swipeResetTrigger,
-            itemCallbacks = itemCallbacks,
-            emptyPurchasedTitle = emptyPurchasedTitle,
-            iconResolver = iconResolver
-        )
+        if (isPurchasedSectionExpanded) {
+            purchasedItemsSection(
+                purchasedItems = uiState.purchasedItems,
+                swipeResetTrigger = swipeResetTrigger,
+                itemCallbacks = itemCallbacks,
+                emptyPurchasedTitle = emptyPurchasedTitle,
+                iconResolver = iconResolver
+            )
+        }
     }
 }
+
+private fun sectionTitle(title: String, count: Int): String = "$title \u00b7 $count"
 
 private fun androidx.compose.foundation.lazy.LazyListScope.pendingItemsSection(
     pendingItems: List<ShoppingItem>,

--- a/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/PurchasedSectionStateTest.kt
+++ b/app/src/test/java/com/jhow/shopplist/presentation/shoppinglist/PurchasedSectionStateTest.kt
@@ -1,0 +1,54 @@
+package com.jhow.shopplist.presentation.shoppinglist
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PurchasedSectionStateTest {
+    @Test
+    fun `empty list expands purchased section by default`() {
+        assertEquals(
+            PurchasedSectionVisibility.Expanded,
+            PurchasedSectionState.resolve(pendingCount = 0, purchasedCount = 0, userExpanded = null)
+        )
+    }
+
+    @Test
+    fun `pending only list collapses purchased section by default`() {
+        assertEquals(
+            PurchasedSectionVisibility.Collapsed,
+            PurchasedSectionState.resolve(pendingCount = 3, purchasedCount = 0, userExpanded = null)
+        )
+    }
+
+    @Test
+    fun `purchased only list expands purchased section by default`() {
+        assertEquals(
+            PurchasedSectionVisibility.Expanded,
+            PurchasedSectionState.resolve(pendingCount = 0, purchasedCount = 2, userExpanded = null)
+        )
+    }
+
+    @Test
+    fun `mixed list collapses purchased section by default`() {
+        assertEquals(
+            PurchasedSectionVisibility.Collapsed,
+            PurchasedSectionState.resolve(pendingCount = 4, purchasedCount = 2, userExpanded = null)
+        )
+    }
+
+    @Test
+    fun `user expanded choice overrides the default collapse rule`() {
+        assertEquals(
+            PurchasedSectionVisibility.Expanded,
+            PurchasedSectionState.resolve(pendingCount = 4, purchasedCount = 2, userExpanded = true)
+        )
+    }
+
+    @Test
+    fun `user collapsed choice overrides the default expand rule`() {
+        assertEquals(
+            PurchasedSectionVisibility.Collapsed,
+            PurchasedSectionState.resolve(pendingCount = 0, purchasedCount = 2, userExpanded = false)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add pure `PurchasedSectionState` for the purchased-section collapse rule.
- Show counts in Pending and Purchased section headers.
- Collapse Purchased rows by default while pending items remain, with a tappable header to expand/collapse for the current session.
- Keep Purchased expanded by default when there are no pending items.

## Verification

- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `ANDROID_SERIAL=emulator-5554 ./gradlew connectedDebugAndroidTest`
- `ANDROID_SERIAL=emulator-5554 ./gradlew verifyDebugCoverage`

Closes #65
Refs #55