### PR TITLE
Support Android 13 as minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Corout
 
 GitHub Releases is the canonical distribution channel for release APKs.
 
+- Requires Android 13 (API 33) or newer.
 - Fast install: open the releases page above and download the latest signed APK.
 - Obtainium: click the badge above or add `https://github.com/Jhonattan-Souza/JhowShoppList` as a GitHub source to install and receive updates from GitHub Releases.
 - AppVerifier: use the package name below and the SHA-256 fingerprint before installing a downloaded APK.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,7 +97,7 @@ android {
 
     defaultConfig {
         applicationId = "com.jhow.shopplist"
-        minSdk = 36
+        minSdk = 33
         targetSdk = 36
         versionCode = appVersionCode
         versionName = appVersionName

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:enableOnBackInvokedCallback="true"
             android:exported="true"
             android:theme="@style/Theme.JhowShoppList"
             android:windowSoftInputMode="stateHidden|adjustResize">

--- a/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/HapticVocabulary.kt
+++ b/app/src/main/java/com/jhow/shopplist/presentation/shoppinglist/HapticVocabulary.kt
@@ -1,5 +1,6 @@
 package com.jhow.shopplist.presentation.shoppinglist
 
+import android.os.Build
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 
@@ -11,7 +12,11 @@ class HapticVocabulary(private val hapticFeedback: HapticFeedback) {
     fun restore() = lightTap()
 
     fun swipeThreshold() {
-        hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+        } else {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
     }
 
     fun multiSelectEntry() {


### PR DESCRIPTION
## Summary
- Lower the app minimum SDK from API 36 to Android 13/API 33 while keeping compile/target SDK at 36.
- Add an API 33-safe fallback for swipe-threshold haptics and opt the activity into predictive back callbacks.
- Document the Android 13 minimum requirement for GitHub Releases/Obtainium users.

## Release Notes
- Requires Android 13 (API 33) or newer.

## Verification
- `./gradlew lintDebug testDebugUnitTest assembleDebug lintRelease assembleRelease`
- Confirmed merged debug manifest has `android:minSdkVersion=\"33\"` and `android:targetSdkVersion=\"36\"`.
- Confirmed connected emulator API level was 33.
- `./gradlew connectedDebugAndroidTest` passed on API 33 emulator after rerun.

## Review Notes
- `code-reviewer` returned `APPROVED_FOR_PR`.
- First API 33 instrumented run had one Compose UI timing failure in `ShoppingListScreenTest.swipingPendingItemAndTappingUndoRestoresIt`; the test passed in isolation and the full suite passed on rerun.
- Tracked the flaky snackbar undo instrumentation test in #87.