### PR TITLE
[codex] Fix Obtainium badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Android shopping list app built with Kotlin, Jetpack Compose, Room, Hilt, Corout
 ## Installation
 
 [![Get it on GitHub Releases](.github/assets/get-it-on-github.svg)](https://github.com/Jhonattan-Souza/JhowShoppList/releases)
-[![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png)](https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22com.jhow.shopplist%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FJhonattan-Souza%2FJhowShoppList%22%2C%22author%22%3A%22Jhonattan-Souza%22%2C%22name%22%3A%22JhowShoppList%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Afalse%2C%5C%22fallbackToOlderReleases%5C%22%3Atrue%2C%5C%22verifyLatestTag%5C%22%3Atrue%2C%5C%22versionDetection%5C%22%3Atrue%2C%5C%22autoApkFilterByArch%5C%22%3Atrue%2C%5C%22appName%5C%22%3A%5C%22JhowShoppList%5C%22%2C%5C%22shizukuPretendToBeGooglePlay%5C%22%3Afalse%2C%5C%22allowInsecure%5C%22%3Afalse%2C%5C%22exemptFromBackgroundUpdates%5C%22%3Afalse%2C%5C%22skipUpdateNotifications%5C%22%3Afalse%2C%5C%22refreshBeforeDownload%5C%22%3Atrue%7D%22%7D)
+<a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/Jhonattan-Souza/JhowShoppList"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" width="220"></a>
 
 GitHub Releases is the canonical distribution channel for release APKs.
 


### PR DESCRIPTION
## What changed

- Replaced the Obtainium badge target with the documented `obtainium://add/...` redirect flow.
- Kept the badge rendered through an HTML image with `width="220"` so it aligns with the GitHub Releases badge size.

## Why

The previous badge used an `obtainium://app/...` link with a full embedded app configuration. That format is valid, but it can carry stale settings and may lead users to see different release/version behavior. The `/add` flow lets Obtainium resolve the GitHub source with current defaults while still pre-filling this repository.

## Validation

- Confirmed the latest GitHub release is `v0.4.1` and contains `app-release.apk` plus `app-release.apk.sha256`.
- Ran `git diff --check HEAD~1..HEAD`.
- Android lint/build not run because this is README-only.